### PR TITLE
Refactor eval AST with monads

### DIFF
--- a/pkgs/collective-lib/eval/monad.nix
+++ b/pkgs/collective-lib/eval/monad.nix
@@ -171,6 +171,14 @@ rec {
               s' = compose mb.s s;
               A' = getT e'.right;
             in Eval A' s' e';
+        # Catch specific error types and handle them with a recovery function
+        # catch :: (EvalError -> Eval A) -> Eval A
+        catch = handler:
+          if isLeft e then 
+            let errorValue = e.left;
+                recovery = handler errorValue;
+            in recovery
+          else this;
         # Returns (Either EvalError set)
         run = state: this.e.fmap (a: { s = this.get; inherit a; });
       };


### PR DESCRIPTION
Refactor `eval/ast.nix` to use the Monadic interface and split `doEvalAST` into smaller, composable functions.

The previous implementation relied on manual `Abort.check` calls and explicit wrapping/unwrapping of `Eval` monad results. This PR replaces these with consistent use of `bind`, `fmap`, and `pure` for automatic error propagation and better functional composition. The monolithic `doEvalAST` function is now broken down into specialized monadic evaluation functions for each AST node type.

---

**Open Background Agent:** 

[Web](https://www.cursor.com/agents?id=bc-ff7c9cdb-a4c2-4d4a-aaf6-4b9613963196) · [Cursor](https://cursor.com/background-agent?bcId=bc-ff7c9cdb-a4c2-4d4a-aaf6-4b9613963196)

Refer to [Background Agent docs](https://docs.cursor.com/background-agents)