### PR TITLE
Create independent nix-reflect flake

### DIFF
--- a/flakes/nix-reflect-local/flake.nix
+++ b/flakes/nix-reflect-local/flake.nix
@@ -1,0 +1,51 @@
+{
+  description = "Nix library for parsing and evaluating Nix code (standalone subflake).";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+
+    # Upstream collective-public to depend on and use as a library
+    collective-public.url = "github:harryaskham/collective-public";
+
+    # Parsec library used by the parser module
+    nix-parsec.url = "github:nprindle/nix-parsec";
+  };
+
+  outputs = { self, nixpkgs, flake-utils, collective-public, nix-parsec, ... } @ inputs:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+        lib = pkgs.lib;
+
+        # Upstream base library from collective-public for this system
+        baseLib = collective-public.packages.${system}.collective-lib;
+
+        # A small, standalone library that depends on upstream baseLib but
+        # only exposes the local parser, eval and debuglib.
+        reflectLib = rec {
+          parser = import ./lib/parser/default.nix {
+            inherit lib;
+            collective-lib = baseLib;
+            inherit nix-parsec;
+          };
+
+          eval = import ./lib/eval/default.nix {
+            inherit lib;
+            collective-lib = baseLib;
+            parser = parser;
+          };
+
+          debuglib = import ./lib/debuglib.nix {
+            inherit lib;
+            collective-lib = baseLib;
+          };
+        };
+      in {
+        lib = reflectLib;
+        devShells.default = pkgs.mkShell { };  
+      }
+    ) // {
+      inherit inputs;
+    };
+}

--- a/flakes/nix-reflect-local/lib/debuglib.nix
+++ b/flakes/nix-reflect-local/lib/debuglib.nix
@@ -1,0 +1,294 @@
+let
+  # NOTE: This data is fixed in place at the top of the file such that it
+  # has a predictable line location.
+  testData = {
+    abc = 123;
+    def = 456;
+    deeper = {
+      ghi = 789;
+    };
+  };
+  testSortData = {
+    z = "z";
+    b = "b"; a = "a";
+  };
+  testArgNames = {
+    zArg,
+    bArg, aArg
+  }: {};
+in
+
+{ lib, collective-lib, ... }:
+
+with lib;
+with collective-lib.syntax;
+
+let
+  log = collective-lib.log;
+  errors = collective-lib.errors;
+  typed = collective-lib.typed;
+in with typed; rec {
+
+  # Get metadata for the given value.
+  # Currently only includes pos.
+  __meta = dispatch {
+    set = xs: {
+      pos = pos xs;
+    };
+  };
+
+  # Is x a raw position from the builtin fn?
+  isRawPos = x: 
+    x ? column && x ? line && x ? file;
+
+  # Does p occur before q in the source file?
+  cmpPos = p: q:
+    assert that (p.file == q.file) ''
+      pos.cmpPos: p.file (${p.file}) != q.file (${q.file})
+    '';
+    p.line < q.line || (p.line == q.line && p.column < q.column);
+
+  # Sort a list of positions by their source file location.
+  sortPosList = sort cmpPos;
+  sortedPos = xs: sortPosList (attrValues (pos xs));
+
+  # Get the position of the given attrPath in the given expr.
+  pathPos = attrPath: expr:
+    if length attrPath == 0 then null
+    else 
+      let 
+        go = attrPath: parent:
+          if length attrPath == 1 then pos (head attrPath) parent
+          else go (tail attrPath) (parent.${head attrPath});
+      in go attrPath expr;
+
+  isPos = x: x ? __isPos;
+  isPosAttrs = x: isAttrs x && nonEmpty x && isPos (head (attrValues x));
+
+  # Get the internal metadata of the given name in the given attrs.
+  pos = 
+    let 
+      mkPos = name: rawPos: 
+        if rawPos == null then null else
+        rawPos // {
+          inherit name;
+          __isPos = true;
+          __toString = self: 
+            "${self.name} (${self.file}:${toString self.line}:${toString self.column})";
+        };
+
+      dispatchPos = f: dispatch.def null {
+        # If given a set, get positions for all its members
+        set = attrs: 
+          (Unsafe.mapAttrs (name: _: mkPos name (f name attrs)) attrs);
+
+        # Otherwise just the one key.
+        string = name: attrs: mkPos name (f name attrs);
+      };
+
+    in {
+      # Default to filename only for replicable output.
+      __functor = self: self.file;
+
+      # Returns null if the name is not present.
+      # File path is absolute.
+      path = dispatchPos builtins.unsafeGetAttrPos;
+
+      # Returns null if the name is not present.
+      # File is filename-only.
+      file = 
+        let elidePos = p: if p == null then null 
+                          else p // { file = builtins.baseNameOf p.file; };
+        in dispatchPos (name: attrs: elidePos (pos.path name attrs));
+
+      deep = 
+        deepMapParent
+          (parent: k: v:
+            if isAttrs parent then pos k parent
+            else v);
+    };
+
+  defaultPrintPosOpts = {
+    linesBefore = 0;
+    linesAfter = 0;
+    printHeader = false;
+    printEllipses = false;
+    posSep = "\n";
+    maxDepth = 5;
+    emptyMsg = "<printPos_: no position information available>";
+    errorMsg = "<printPos_: error printing pos>";
+  };
+
+  printPos_ = opts: p: 
+    log.while "printing the positional information for a value" (
+    flip errors.tryStrict (_: opts.errorMsg) (
+    if p == null || (isAttrs p && all (x: x == null) (attrValues p)) then
+      opts.emptyMsg
+
+    else if opts.maxDepth <= 0 then
+      "<printPos_: maxDepth reached>"
+
+    else if !(isPos p || isPosAttrs p) then
+      assert that (isAttrs p) ''
+        debuglib.printPos: cannot print non-attrs pos p
+      '';
+      log.while "obtaining positional information for printing" (
+      printPos_ opts (pos.path p)
+      )
+
+    else if isPosAttrs p then
+      log.while "printing positional information for an attrset" (
+      joinSep opts.posSep 
+        (mapAttrsToList 
+          (_: printPos_ (opts // { maxDepth = opts.maxDepth - 1; }))
+          p)
+      )
+
+    else
+      log.while "printing positional information for an individual position" (
+      let sourceLines = splitLines (builtins.readFile p.file);
+          toEnd = p.line + opts.linesAfter >= length sourceLines;
+          fromStart = p.line - opts.linesBefore < 1;
+          lines = 
+            take 
+              (1 + opts.linesBefore + opts.linesAfter) 
+              (drop (p.line - opts.linesBefore) sourceLines);
+          header = if opts.printHeader then "${toString p}\n---" else "";
+          truncatedSource = _ls_ (
+            (optionals (!fromStart && opts.printEllipses) ["..."]) ++
+            (lines) ++
+            (optionals (!toEnd && opts.printEllipses) ["..."])
+          );
+      in _ls_ [header truncatedSource]
+      )
+  ));
+
+  printPos = x: 
+    log.while "printing the default positinal information for a value" (
+    printPos_ defaultPrintPosOpts x
+    );
+  printPosWith = opts: x: printPos_ (defaultPrintPosOpts // opts) x;
+
+  # <nix>debuglib._tests.run {}</nix>
+  _tests = with collective-lib.tests; suite {
+    pos = 
+      let 
+        expectedPosABC = {
+          name = "abc";
+          column = 5;
+          line = 5;
+          file = "debuglib.nix";
+          __toString = expect.anyLambda;
+        };
+        expectedPosDEF = {
+          name = "def";
+          column = 5;
+          line = 6;
+          file = "debuglib.nix";
+          __toString = expect.anyLambda;
+        };
+        expectedPosDeeper = {
+          name = "deeper";
+          column = 5;
+          line = 7;
+          file = "debuglib.nix";
+          __toString = expect.anyLambda;
+        };
+        expectedPosGHI = {
+          name = "ghi";
+          column = 7;
+          line = 8;
+          file = "debuglib.nix";
+          __toString = expect.anyLambda;
+        };
+        expectedPosZ = {
+          name = "z";
+          column = 5;
+          line = 12;
+          file = "debuglib.nix";
+          __toString = expect.anyLambda;
+        };
+        expectedPosB = {
+          name = "b";
+          column = 5;
+          line = 13;
+          file = "debuglib.nix";
+          __toString = expect.anyLambda;
+        };
+        expectedPosA = {
+          name = "a";
+          column = 14;
+          line = 13;
+          file = "debuglib.nix";
+          __toString = expect.anyLambda;
+        };
+        expectedPosZArg = {
+          name = "zArg";
+          column = 5;
+          line = 16;
+          file = "debuglib.nix";
+          __toString = expect.anyLambda;
+        };
+        expectedPosBArg = {
+          name = "bArg";
+          column = 5;
+          line = 17;
+          file = "debuglib.nix";
+          __toString = expect.anyLambda;
+        };
+        expectedPosAArg = {
+          name = "aArg";
+          column = 11;
+          line = 17;
+          file = "debuglib.nix";
+          __toString = expect.anyLambda;
+        };
+        expectedPosAll = {
+          abc = expectedPosABC;
+          def = expectedPosDEF;
+          deeper = expectedPosDeeper;
+        };
+        expectedPosDeep = {
+          abc = expectedPosABC;
+          def = expectedPosDEF;
+          deeper = {
+            ghi = expectedPosGHI;
+          };
+        };
+      in {
+        present = expect.noLambdasEq (pos "abc" testData) expectedPosABC;
+        absent = expect.eq (pos "xyz" testData) null;
+        nested.present = expect.noLambdasEq (pos "abc" ({ deep = testData; }).deep) expectedPosABC;
+        nested.absent = expect.eq (pos "abc" { deep = testData; }) null;
+        merged.present = expect.noLambdasEq (pos "abc" ({} // testData)) expectedPosABC;
+        overwritten.present = expect.noLambdasEq (pos "abc" ({abc = 456; } // testData)) expectedPosABC;
+        # Inherits / merge-right now looks for that field in the copied attrs, so we lose the information.
+        overwritten.here = expect.True (((pos "abc" (testData // {abc = 456; })).line) > expectedPosABC.line);
+        inherits.here = expect.True ((pos "abc" {inherit (testData) abc;}).line > expectedPosABC.line);
+        attrs.all = expect.noLambdasEq (pos testData) expectedPosAll;
+        attrs.deep = expect.noLambdasEq (pos.deep testData) expectedPosDeep;
+        # Can't pull attrs out of derived set.
+        attrs.overwrite.noset =
+          expect.noLambdasEq
+            (pos (mapAttrs (_: _: 9) testData))
+            {abc = null; def = null; deeper = null;};
+        # Can't pull attrs out of derived set.
+        attrs.inside.lambda = 
+          let f = data: pos "abc" data;
+          in expect.noLambdasEq (f testData) expectedPosABC;
+        toString = expect.eq (toString (pos "abc" testData)) "abc (debuglib.nix:5:5)";
+        sortPos.nosorted = expect.noLambdasEq (attrValues (pos testSortData)) [expectedPosA expectedPosB expectedPosZ];
+        sortPos.sorted = expect.noLambdasEq (sortedPos testSortData) [expectedPosZ expectedPosB expectedPosA];
+        sortPos.argOrder.nosorted = 
+          expect.noLambdasEq
+            (attrValues (pos (builtins.functionArgs testArgNames)))
+            [expectedPosAArg expectedPosBArg expectedPosZArg];
+        sortPos.argOrder.sorted = 
+          expect.noLambdasEq
+            (sortedPos (builtins.functionArgs testArgNames))
+            [expectedPosZArg expectedPosBArg expectedPosAArg];
+        pathPos = expect.noLambdasEq (pathPos ["deeper" "ghi"] testData) expectedPosGHI;
+      };
+  };
+
+}

--- a/flakes/nix-reflect-local/lib/eval/ast.nix
+++ b/flakes/nix-reflect-local/lib/eval/ast.nix
@@ -1,0 +1,811 @@
+{ lib, collective-lib, parser, eval, ... }:
+
+with collective-lib.typed;
+with eval.monad;
+
+let
+  parse = parser.parse;
+  inherit (parser) AST N;
+in rec {
+  # Module callable as eval.ast
+  __functor = self: self.evalAST;
+
+  /*
+  Parse the expression in the Eval monad and drop the state from the result.
+
+  Exposed as eval.eval.ast (and eval.eval) in default.nix for use as just "eval"
+ 
+  runAST :: (string | AST) -> Either EvalError {a :: a, s :: EvalState} */
+  runAST = expr:
+    (Eval.do
+      (while "running string or AST node evaluation")
+      (evalM expr))
+    .run (EvalState.mempty {});
+
+  /*
+  evalAST :: (string | AST) -> Either EvalError a */
+  evalAST = expr:
+    (Eval.do
+      (while "evaluating string or AST node")
+      (evalM expr))
+    .run_ (EvalState.mempty {});
+
+  /*
+  evalM :: (string | AST) -> Eval a */
+  evalM = expr:
+    Eval.do
+      (while "running string or AST node evaluation")
+      (set initEvalState)
+      (evalNodeM (parse expr));
+
+  /* Main monadic eval entrypoint.
+  evalNodeM :: AST -> Eval a */
+  evalNodeM = node:
+    Eval.do
+      (while "evaluating AST node of type '${node.nodeType or "<no .nodeType>"}'")
+      ({_}: if is EvalError node then _.liftEither node else _.pure unit)
+      ({_}: _.guard (is AST node) (RuntimeError ''
+        evalNodeM: Expected AST node, got ${_ph_ node}
+      ''))
+      (switch node.nodeType {
+        int = evalLiteral node;
+        float = evalLiteral node;
+        string = evalLiteral node;
+        indentString = evalLiteral node;
+        path = evalPath node;
+        anglePath = evalAnglePath node;
+        list = evalList node;
+        attrs = evalAttrs node;
+        identifier = evalIdentifier node;
+        binaryOp = evalBinaryOp node;
+        unaryOp = evalUnaryOp node;
+        conditional = evalConditional node;
+        lambda = evalLambda node;
+        application = evalApplication node;
+        letIn = evalLetIn node;
+        "with" = evalWith node;
+        "assert" = evalAssert node;
+        "abort" = evalAbort node;
+        "throw" = evalThrow node;
+        "import" = evalImport node;
+        "assignment" = evalAssignment node;
+        "inherit" = evalInherit node;
+      });
+
+  # Evaluate a literal value (int, float, string, etc.)
+  # evalLiteral :: AST -> Eval a
+  evalLiteral = node: 
+    Eval.do
+      (while "evaluating 'literal' node")
+      (pure node.value);
+
+  # Evaluate a name (identifier or string)
+  # If identifier, get the name itself, not evaluate it.
+  # This can then be used on LHS of assignments.
+  # Could also be a string or an interpolation.
+  identifierName = node:
+    Eval.do
+      (while "evaluating a name")
+      {name = 
+        if node.nodeType == "identifier"
+        then {_, ...}: _.pure node.name
+        else evalNodeM node;}
+      ({_, name}: _.guard (lib.isString name) (RuntimeError ''
+        Expected string identifier name, got ${lib.typeOf name}
+      ''))
+      ({_, name}: _.pure name);
+
+  # Evaluate an identifier lookup
+  # evalIdentifier :: Scope -> AST -> Eval a
+  evalIdentifier = node:
+    Eval.do
+      (while "evaluating 'identifier' node")
+      {state = get;}
+      ({_, state}: _.guard (hasAttr node.name state.scope) (UnknownIdentifierError ''
+        Undefined identifier '${node.name}' in current scope:
+          ${_ph_ state.scope}
+      ''))
+      ({_, state}: _.pure state.scope.${node.name});
+
+  # Evaluate a list of AST nodes
+  # evalList :: AST -> Eval [a]
+  evalList = node:
+    Eval.do
+      (while "evaluating 'list' node")
+      (traverse evalNodeM node.elements);
+
+  # Evaluate an assignment (name-value pair)
+  # evalAssignment :: AST -> Eval [{name, value}]  
+  evalAssignment = node:
+    Eval.do
+      (while "evaluating 'assignment' node")
+      {name = identifierName node.lhs;}
+      {value = evalNodeM node.rhs;}
+      ({_, name, value}: _.pure [{ inherit name value; }]);
+
+  # Evaluate an attribute from a source
+  # evalAttrFrom :: a -> AST -> Eval {name, value}  
+  evalAttrFrom = from: attr:
+    Eval.do
+      (while "evaluating 'attr' node by name")
+      {name = identifierName attr;}
+      ({_, name}: _.guard (hasAttr name from) (MissingAttributeError name))
+      ({_, name}: _.pure { inherit name; value = from.${name}; });
+
+  # Evaluate an inherit expression, possibly with a source
+  # evalInherit :: AST -> Eval [{name, value}]
+  evalInherit = inheritNode:
+    Eval.do
+      (while "evaluating 'inherit' node")
+      {from = 
+        if inheritNode.from == null 
+        then getScope
+        else evalNodeM inheritNode.from;}
+      ({_, from}: _.traverse (evalAttrFrom from) inheritNode.attrs);
+
+  # Evaluate an inherit expression
+  # evalBindingList :: AST -> Eval set
+  evalBindingList = bindings:
+    Eval.do
+      (while "evaluating 'bindings' node-list")
+      {attrsList = traverse evalNodeM bindings;}
+      {attrs = {_, attrsList}: _.pure (concatLists attrsList);}
+      ({_, attrs}: _.guard (all (attr: (hasAttr "name" attr) && (hasAttr "value" attr)) attrs) (RuntimeError ''
+        Recursive binding list evaluation produced invalid name/value pairs:
+          bindings: ${_ph_ bindings}
+          attrs: ${_ph_ attrs}
+      ''))
+      ({_, attrs, ...}: _.pure (listToAttrs attrs));
+
+  # Evaluate an attribute set
+  # evalAttrs :: AST -> Eval AttrSet
+  evalAttrs = node:
+    Eval.do
+      (while "evaluating 'attrs' node")
+      (if node.isRec 
+      then evalRecBindingList node.bindings
+      else evalBindingList node.bindings);
+
+  # Evaluate a binding without failing on missing names.
+  # evalRecBinding :: AST -> Eval [{name, value}]
+  evalRecBinding = binding:
+    (Eval.do
+      (while "evaluating 'binding' node for recursive bindings")
+      (evalNodeM binding))
+    .catch ({_, _e}: _.do
+      (while "Handling missing binding in recursive binding list")
+      ({_}: _.guard (UnknownIdentifierError.check _e) _e)
+      ({_}: _.pure []));
+
+  evalRecBindingList = bindings: Eval.do (evalRecBindingList_ 0 bindings);
+  evalRecBindingList_ = i: bindings:
+    Eval.do
+      (while "evaluating 'bindings' node-list recursively, iteration ${toString i}")
+      {state = get;}
+      {attrsList = traverse evalRecBinding bindings;}
+      {attrs = {_, attrsList}: _.pure (listToAttrs (concatLists attrsList));}
+      ({_, attrs, state, ...}: _.set (EvalState (attrs // state.scope)))
+      ({_, attrsList, attrs, state, ...}: _.guard (i <= size bindings) (RuntimeError ''
+        Recursive binding list evaluation failed to complete at iteration ${toString i}:
+          ${_ph_ bindings}
+
+        attrsList (this iteration):
+          ${_ph_ attrsList}
+
+        attrs:
+          ${_ph_ attrs}
+
+        state:
+          ${_ph_ state}
+      ''))
+      ({_, attrs, ...}: 
+        if size bindings == size attrs then _.pure attrs
+        else evalRecBindingList_ (i + 1) bindings);
+
+  # Type-check binary operation operands
+  # checkBinaryOpTypes :: String -> [TypeSet] -> a -> a -> Eval Unit
+  checkBinaryOpTypes = op: compatibleTypeSets: l: r: result:
+    if any id 
+      (map 
+        (typeSet: elem (lib.typeOf l) typeSet && elem (lib.typeOf r) typeSet)
+        compatibleTypeSets)
+    then Eval.pure result
+    else Eval.throws (TypeError (_b_ ''Incorrect types for binary operator ${op}:
+
+      ${_ph_ l} and ${_ph_ r}
+      
+      (expected one of ${
+        joinSep " | " 
+          (map 
+            (typeSet: "(${joinSep " | " typeSet})") 
+            compatibleTypeSets)})
+    ''));
+
+  guardOneBinaryOp = op: compatibleTypeSets: l: r:
+    {_, ...}:
+      _.guard 
+        (any id 
+          (map 
+            (typeSet: elem (lib.typeOf l) typeSet && elem (lib.typeOf r) typeSet)
+            compatibleTypeSets))
+        (TypeError ''Incorrect types for binary operator ${op}:
+
+          ${_ph_ l} and ${_ph_ r}
+          
+          (expected one of ${
+            joinSep " | " 
+              (map 
+                (typeSet: "(${joinSep " | " typeSet})") 
+                compatibleTypeSets)})
+        '');
+
+  guardBinaryOp = op: l: r: switch op {
+    "+" = guardOneBinaryOp "+" [["int" "float"] ["string" "path"]] l r;
+    "-" = guardOneBinaryOp "-" [["int" "float"]] l r;
+    "*" = guardOneBinaryOp "*" [["int" "float"]] l r;
+    "/" = guardOneBinaryOp "/" [["int" "float"]] l r;
+    "++" = guardOneBinaryOp "++" [["list"]] l r;
+    "//" = guardOneBinaryOp "//" [["set"]] l r;
+    "==" = guardOneBinaryOp "==" [builtinNames] l r;
+    "!=" = guardOneBinaryOp "!=" [builtinNames] l r;
+    "<" = guardOneBinaryOp "<" [["int" "float"] ["string"] ["path"] ["list"] ["set"]] l r;
+    ">" = guardOneBinaryOp ">" [["int" "float"] ["string"] ["path"] ["list"] ["set"]] l r;
+    "<=" = guardOneBinaryOp "<=" [["int" "float"] ["string"] ["path"] ["list"] ["set"]] l r;
+    ">=" = guardOneBinaryOp ">=" [["int" "float"] ["string"] ["path"] ["list"] ["set"]] l r;
+  };
+
+  runBinaryOp = op: l: r: switch op {
+    "+" = l + r;
+    "-" = l - r;
+    "*" = l * r;
+    "/" = l / r;
+    "++" = l ++ r;
+    "//" = l // r;
+    "==" = l == r;
+    "!=" = l != r;
+    "<" = l < r;
+    ">" = l > r;
+    "<=" = l <= r;
+    ">=" = l >= r;
+  };
+
+  knownBinaryOps = [
+    "+"
+    "-"
+    "*"
+    "/"
+    "++"
+    "//"
+    "=="
+    "!="
+    "<"
+    ">"
+    "<="
+    ">="
+    "&&"
+    "||"
+    "."
+    "or"
+  ];
+
+  # Evaluate a binary operation
+  # evalBinaryOp :: AST -> Eval a
+  evalBinaryOp = node:
+    Eval.do
+      (while "evaluating 'binaryOp' node")
+      ({_}: _.guard (elem node.op knownBinaryOps) (RuntimeError ''
+        Unsupported binary operator: ${node.op}
+      ''))
+      (
+        if node.op == "." then evalAttributeAccess node
+        else if node.op == "or" then evalOrOperation node
+        else {_, ...}: _.do
+          {l = evalNodeM node.lhs;}
+          {r = evalNodeM node.rhs;}
+          ({_, l, r, ...}:
+            # && operator separated out to add short-circuiting.
+            if node.op == "&&" then
+              if !(lib.isBool l) || (l && !(lib.isBool r)) then _.throws (TypeError (_b_ ''
+                &&: got non-bool operand(s) of type ${typeOf l} and ${typeOf r}
+              '')) else _.pure (l && r)
+
+            # || operator separated out to add short-circuiting.
+            else if node.op == "||" then
+              if !(lib.isBool l) || (!l && !(lib.isBool r)) then _.throws (TypeError (_b_ ''
+                ||: got non-bool operand(s) of type ${typeOf l} and ${typeOf r}
+              '')) else _.pure (l || r)
+
+
+            # All other binary operators.
+            else _.do
+              (guardBinaryOp node.op l r)
+              ({_}: _.pure (runBinaryOp node.op l r))
+        ));
+
+  # obj.a.b.c - traverse the attribute path
+  traversePath = obj: components:
+    Eval.do
+      (while "traversing attr path")
+      ({_, ...}:
+        if components == [] then _.pure obj
+        else 
+          let headPath = builtins.head components;
+              restPath = builtins.tail components;
+          in _.do
+            {attrName = identifierName headPath;}
+            ({_, attrName, ...}: _.guard (hasAttr attrName obj) (MissingAttributeError attrName))
+            ({_, attrName, ...}: traversePath obj.${attrName} restPath));
+
+  # Evaluate attribute access (dot operator)
+  # evalAttributeAccess :: AST -> Eval a
+  evalAttributeAccess = node:
+    Eval.do
+      (while "evaluating 'attribute access' node")
+      {obj = evalNodeM node.lhs;}
+      (
+        # obj.a or b
+        if node.rhs.nodeType == "binaryOp" && node.rhs.op == "or" then
+          {_, obj, ...}: _.do
+            { defaultVal = evalNodeM node.rhs.rhs; }
+            { attrName = identifierName node.rhs.lhs; }
+            ( {_, attrName, defaultVal, ...}: _.pure (obj.${attrName} or defaultVal) )
+
+        # obj.a
+        else if node.rhs.nodeType == "attrPath" then
+          ({_, obj, ...}: traversePath obj node.rhs.path)
+
+        else 
+          _.throws (RuntimeError ''
+            Unsupported attribute access: ${node.rhs.nodeType}
+            (Expected 'attrPath' or 'binaryOp' with 'or' operator)
+          ''));
+
+  # evalOrOperation :: AST -> Eval a
+  evalOrOperation = node:
+    (Eval.do
+      (while "evaluating 'or' node")
+      ({_}: _.guard (node.lhs.nodeType == "binaryOp" && node.lhs.op == ".") (RuntimeError ''
+        Unsupported 'or' after non-select: ${node.lhs.nodeType} or ...
+      ''))
+      (evalNodeM node.lhs))
+    .catch ({_, _e}: _.do
+        (while "Handling missing attribute in 'or' node")
+        ({_}: _.guard (MissingAttributeError.check _e) _e)
+        (evalNodeM node.rhs));
+
+  # evalUnaryOp :: AST -> Eval a
+  evalUnaryOp = node:
+    Eval.do
+      (while "evaluating 'unary' node")
+      {operand = evalNodeM node.operand;}
+      ({_, operand}: _.pure (switch node.op {
+        "!" = (!operand);
+        "-" = (-operand);
+      }));
+
+  # evalConditional :: AST -> Eval a
+  evalConditional = node:
+    Eval.do
+      (while "evaluating 'conditional' node")
+      {cond = evalNodeM node.cond;}
+      ({_, cond}:
+        if cond 
+        then evalNodeM node."then" 
+        else evalNodeM node."else");
+
+  paramName = param: param.name.name;
+  defaultParamAttrs = param: filter (paramAttr: paramAttr.nodeType == "defaultParam") param.attrs;
+  requiredParamAttrs = param: filter (paramAttr: paramAttr.nodeType != "defaultParam") param.attrs;
+
+  getDefaultLambdaScope = param:
+    traverse
+      (paramAttr: 
+        Eval.do
+          {default = evalNodeM paramAttr.default;}
+          ({_, default}: _.pure { ${paramName paramAttr} = default;}))
+      (defaultParamAttrs param);
+
+  # Return any extra scope bound by passing in the arg to the param.
+  # evalLambdaParams :: AST -> a -> Eval Scope
+  evalLambdaParams = param: arg:
+    Eval.do
+      (while "evaluating 'lambda' parameters")
+      ({_}: switch.on (p: p.nodeType) param {
+        # Simple param is just a name, so just bind it to the arg.
+        simpleParam = _.pure { ${paramName param} = arg; };
+
+        # Attrset param is a set of names, so bind each to the arg, with defaults handled.
+        attrSetParam = 
+          let 
+            allParamNames = map paramName param.attrs;
+            requiredParamNames = map paramName (requiredParamAttrs param);
+            suppliedUnknownNames = removeAttrs arg allParamNames;
+            requiredUnsuppliedNames = filter (name: !(hasAttr name arg)) requiredParamNames;
+          in
+            _.do
+              ({_}: _.guard (lib.isAttrs arg) (TypeError ''
+                Expected attrset argument, got ${lib.typeOf arg}:
+                  ${_ph_ arg}
+              ''))
+              ({_}: _.guard (empty requiredUnsuppliedNames) (RuntimeError ''
+                Missing required parameters in attrset lambda: ${joinSep ", " requiredUnsuppliedNames}:
+                  ${_ph_ param}
+              ''))
+              ({_}: _.guard (param.ellipsis || empty suppliedUnknownNames) (RuntimeError ''
+                Unknown parameters in non-ellipsis attrset lambda: ${joinSep ", " (attrNames suppliedUnknownNames)}:
+                  ${_ph_ param}
+              ''))
+              {defaults = getDefaultLambdaScope param; }
+              ({_, defaults, ...}: _.pure (defaults // arg) );
+      });
+
+  # Evaluate a lambda expression
+  # evalLambda :: AST -> Eval Function
+  evalLambda = node:
+    Eval.do
+      (while "evaluating 'lambda' node")
+      {state = get;}
+      ({_, state, ...}: _.pure (
+        # Bind arg to create an actual lambda.
+        arg: 
+          let bodyM = 
+            # Start from scratch inside the lambda since we don't
+            # inherit scope.
+            Eval.do
+              (appendScopeM (evalLambdaParams node.param arg))
+              (evalNodeM node.body);
+          in
+            # Actually have to run the Eval monad here to get
+            # correct runtime behaviour.
+            # Can't return a monad in the general case as this
+            # might be evaluated in Eval and later applied outside of the Eval monad.
+            # However we return an unwrapped EvalError if one occurs which
+            # we can throw if we apply during Eval.
+            let e = bodyM.run_ state;
+            #in if isLeft e then e.left else e.right.a
+            in e.case {
+              Left = _: e;
+              Right = a: a;
+            }
+        ));
+
+  # Evaluate function application. If the function was a lambda constructed by
+  # eval, lift any error returned to the top level.
+  # evalApplication :: AST -> Eval a
+  evalApplication = node:
+    Eval.do
+      (while "evaluating 'application' node")
+      {func = evalNodeM node.func;}
+      {args = traverse evalNodeM node.args;}
+      {result = {_, func, args, ...}: _.pure (ap.list func args);}
+      ({_, result, ...}: _.guard (!(is EvalError result)) result)
+      ({_}: _.pure result);
+
+  bindingToAttrs = binding:
+    Eval.do
+      {lhs = identifierName binding.lhs;}
+      {rhs = evalNodeM binding.rhs;}
+      ({_, lhs, rhs, ...}: _.pure { ${lhs} = rhs; });
+
+  # Evaluate a let expression
+  # evalLetIn :: AST -> Eval a
+  evalLetIn = node:
+    Eval.do
+      (while "evaluating 'letIn' node")
+      (saveScope ({_}: _.do
+        {state = get;}
+        {bindings = evalRecBindingList node.bindings;}
+        ({_, state, bindings, ...}: _.set (EvalState (state.scope // bindings)))
+        (evalNodeM node.body)));
+
+  # Evaluate a with expression
+  # evalWith :: AST -> Eval a
+  evalWith = node: 
+    Eval.do
+      (while "evaluating 'with' node")
+      (saveScope ({_}: _.do
+        {state = get;}
+        {env = evalNodeM node.env;}
+        ({_, env, ...}: _.guard (lib.isAttrs env) (TypeError ''
+          with: got non-attrset environment of type ${typeOf env}:
+            ${_ph_ env}
+        ''))
+        ({_, state, env, ...}: _.set (EvalState (env // state.scope)))
+        (evalNodeM node.body)));
+
+  # Evaluate an assert expression
+  # evalAssert :: AST -> Eval a
+  evalAssert = node:
+    Eval.do
+      (while "evaluating 'assert' node")
+      {cond = evalNodeM node.cond;}
+      ({_, cond}: _.guard (lib.isBool cond) (TypeError ''
+        assert: got non-bool condition of type ${typeOf cond}:
+          ${_ph_ cond}
+      ''))
+      ({_, cond}: _.guard cond (AssertError ''
+        assert: condition failed:
+          ${_ph_ cond}
+      ''))
+      (evalNodeM node.body);
+
+  # Evaluate an abort expression
+  # evalAbort :: Scope -> AST -> Eval a
+  evalAbort = node:
+    Eval.do
+      (while "evaluating 'abort' node")
+      {msg = evalNodeM node.msg;}
+      ({_, msg}: _.guard (lib.isString msg) (TypeError ''
+        abort: got non-string message of type ${typeOf msg}:
+          ${_ph_ msg}
+      ''))
+      ({_, msg}: _.throws (Abort msg));
+
+  # Evaluate a throw expression
+  # evalThrow :: Scope -> AST -> Eval a
+  evalThrow = node: 
+    Eval.do
+      (while "evaluating 'throw' node")
+      {msg = evalNodeM node.msg; }
+      ({_, msg}: _.guard (lib.isString msg) (TypeError ''
+        throw: got non-string message of type ${typeOf msg}:
+          ${_ph_ msg}
+      ''))
+      (throws (Throw msg));
+
+  # Evaluate an import expression
+  # evalImport :: Scope -> AST -> Eval a
+  evalImport = node:
+    Eval.do
+      (while "evaluating 'import' node")
+      {path = evalNodeM node.path;}
+      ({_, path}: _.guard (lib.isString path || lib.isPath path) (TypeError ''
+        import: got non-string or path message of type ${typeOf path}:
+          ${_ph_ path}
+      ''))
+      (pure (import path));
+
+  evalPath = node: 
+    Eval.do
+      (while "evaluating 'path' node")
+      (pure (stringToPath node.value));
+
+  evalAnglePath = node:
+    Eval.do
+      (while "evaluating 'anglePath' node")
+      {scope = getScope;}
+      ({_, scope}:
+        let path = splitSep "/" node.value;
+            name = maybeHead path;
+            rest = maybeTail path;
+            restPath = joinSep "/" (def [] rest);
+        in Eval.do
+          ({_}: _.guard (hasAttr "NIX_PATH" scope) (NixPathError ''
+            No NIX_PATH found in scope when resolving ${node.value}.
+          ''))
+          ({_}: _.guard (hasAttr name scope.NIX_PATH) (NixPathError ''
+            ${name} not found in NIX_PATH when resolving ${node.value}.
+          ''))
+          (pure (scope.NIX_PATH.${name} + "/${restPath}")));
+
+  # Helper to test round-trip property: eval (parse x) == x
+  testRoundTrip = testRoundTripWith collective-lib.tests.expect.printEq;
+  testRoundTripWith = expectation: expr: expected: {
+    # Just test that parsing succeeds and the result evaluates to expected
+    roundTrip = 
+      let result = evalAST expr;
+      in expectation result ((Either EvalError (getT expected)).Right expected);
+  };
+
+  expectEvalError = expectEvalErrorWith collective-lib.tests.expect.noLambdasEq;
+  expectEvalErrorWith = expectation: E: expr:
+    let result = runAST expr;
+    in expectation (rec {
+      resultIsLeft = isLeft result;
+      resultEMatches = is E (result.left or null);
+      inherit E;
+      resultE = result.left or null;
+    }) {
+      resultIsLeft = true;
+      resultEMatches = true;
+      inherit E;
+      resultE = result.left or null;
+    };
+
+  _tests = with tests; suite {
+
+    # Tests for evalAST round-trip property
+    evalAST = {
+
+      _00_smoke = {
+        int = testRoundTrip "1" 1;
+        float = testRoundTrip "1.0" 1.0;
+        string = testRoundTrip "\"hello\"" "hello";
+        indentString = testRoundTrip "''hello''" "hello";
+        true = testRoundTrip "true" true;
+        false = testRoundTrip "false" false;
+        null = testRoundTrip "null" null;
+        list = testRoundTrip "[1 2 3]" [1 2 3];
+        attrSet = testRoundTrip "{a = 1;}" {a = 1;};
+        attrPath = testRoundTrip "{a = 1;}.a" 1;
+        attrPathOr = testRoundTrip "{a = 1;}.b or 2" 2;
+        inheritsConst = testRoundTrip "{ inherit ({a = 1;}) a; }" {a = 1;};
+        recAttrSetNoRecursion = testRoundTrip "rec { a = 1; }" {a = 1;};
+        recAttrSetRecursion = testRoundTrip "rec { a = 1; b = a; }" {a = 1; b = 1;};
+        letIn = testRoundTrip "let a = 1; in a" 1;
+        withs = testRoundTrip "with {a = 1;}; a" 1;
+      };
+
+      _01_allFeatures =
+        skip (
+        let 
+          # Test all major language constructs in one expression
+          expr = ''
+            let f = { a ? 1, b, ... }:
+                  let 
+                    data = { 
+                      aa = a;
+                      inherit b;
+                    }; 
+                  in with data; aa + b; 
+            in f {b = 4;}
+          '';
+        in testRoundTrip expr 5
+        );
+
+      # Basic literals
+      _02_literals = {
+        integers = testRoundTrip "42" 42;
+        floats = testRoundTrip "3.14" 3.14;
+        strings = testRoundTrip "\"hello\"" "hello";
+        booleans = {
+          true = testRoundTrip "true" true;
+          false = testRoundTrip "false" false;
+        };
+        nullValue = testRoundTrip "null" null;
+      };
+
+      # Collections
+      _03_lists = {
+        empty = testRoundTrip "[]" [];
+        numbers = testRoundTrip "[1 2 3]" [1 2 3];
+        #mixed = testRoundTrip ''[1 "hello" true]'' [1 "hello" true];
+      };
+
+      _04_attrs = {
+        empty = testRoundTrip "{}" {};
+        simple = testRoundTrip "{ a = 1; b = 2; }" { a = 1; b = 2; };
+        nested = testRoundTrip "{ x = { y = 42; }; }" { x = { y = 42; }; };
+      };
+
+      # Binary operations
+      _05_arithmetic = {
+        addition = testRoundTrip "1 + 2" 3;
+        multiplication = testRoundTrip "3 * 4" 12;
+        subtraction = testRoundTrip "10 - 3" 7;
+        division = testRoundTrip "8 / 2" 4;
+      };
+
+      _06_logical = {
+        and = testRoundTrip "true && false" false;
+        or = testRoundTrip "true || false" true;
+      };
+
+      _07_comparison = {
+        equalParen = testRoundTrip "(1 == 1)" true;
+        equal = testRoundTrip "1 == 1" true;
+        notEqual = testRoundTrip "1 != 2" true;
+        lessThan = testRoundTrip "1 < 2" true;
+        greaterThan = testRoundTrip "3 > 2" true;
+      };
+
+      # Unary operations
+      _08_unary = {
+        not = testRoundTrip "!false" true;
+      };
+
+      # Conditionals
+      _09_conditionals = {
+        simple = testRoundTrip "if true then 1 else 2" 1;
+        nested = testRoundTrip "if false then 1 else if true then 2 else 3" 2;
+      };
+
+      # Let expressions
+      _10_letExpressions = {
+        simple = testRoundTrip "let x = 1; in x" 1;
+        multiple = testRoundTrip "let a = 1; b = 2; in a + b" 3;
+        nested = testRoundTrip "let x = 1; y = let z = 2; in z + 1; in x + y" 4;
+      };
+
+      # Functions (simplified tests since function equality is complex)  
+      _11_functions = skip {
+        identity = testRoundTrip "let f = x: x; in f 42" 42;
+        const = testRoundTrip "let f = x: y: x; in f 1 2" 1;
+      };
+
+      # Attribute access
+      _12_attrAccess = skip {
+        letIn = testRoundTrip "let xs = { a = 42; }; in xs.a" 42;
+        simple = testRoundTrip "{ a = 42; }.a" 42;
+        withDefault = testRoundTrip "{ a = 42; }.b or 0" 0;
+      };
+
+      # Assert expressions - testing proper Nix semantics
+      _13_assertExpressions = {
+        # Assert with true condition should evaluate body
+        assertTrue = testRoundTrip "assert true; 42" 42;
+        # Assert with false condition should throw
+        assertFalse = expectEvalError AssertError "assert false; 42";
+        # Assert with non-boolean values should fail (Nix requires boolean)
+        assertStringFails = expectEvalError TypeError ''assert "error message"; 42'';
+        assertIntegerFails = expectEvalError TypeError "assert 1; 42";
+        assertZeroFails = expectEvalError TypeError "assert 0; 42";
+        # Test with boolean expressions
+        assertBooleanExpr = testRoundTrip "assert (1 == 1); 42" 42;
+      };
+
+      # Abort expressions - testing our custom abort handling
+      _14_abortExpressions = {
+        # Basic abort with string message
+        abortString = expectEvalError Abort ''abort "custom abort message"'';
+        # Abort with evaluated expression
+        abortExpression = expectEvalError Abort ''abort ("a " + "msg")'';
+        # Abort should propagate through binary operations
+        abortPropagation = expectEvalError Abort ''1 + (abort "msg")''; 
+      };
+
+      # With expressions - testing proper scope precedence
+      _15_withExpressions = {
+        # Basic with expression
+        basicWith = testRoundTrip "with { a = 1; }; a" 1;
+        # Lexical scope should shadow with attributes  
+        lexicalShadowing = testRoundTrip "let x = 1; in with { x = 2; }; x" 1;
+        # With attributes act as fallbacks
+        withFallback = testRoundTrip "with { y = 2; }; y" 2;
+        # Nested with expressions
+        nestedWith = testRoundTrip "with { a = 1; }; with { b = 2; }; a + b" 3;
+        # With expression with complex lexical shadowing
+        complexShadowing = testRoundTrip "let a = 10; b = 20; in with { a = 1; c = 3; }; a + b + c" 33;
+      };
+
+      # Import expressions - basic import tests
+      _16_importExpressions = skip {
+        # Import self test (simplified)
+        importSelf = testRoundTrip "let path = ./default.nix; in true" true;
+        paths = {
+          nixpkgs = testRoundTrip "<nixpkgs>" <nixpkgs>;
+          nixpkgsLib = testRoundTrip "<nixpkgs/lib>" <nixpkgs/lib>;
+        };
+        importNixpkgs = testRoundTrip "(import <nixpkgs> {}).lib.isBool true" true;
+        importNixpkgsLib = testRoundTrip "(import <nixpkgs/lib>).isBool true" true;
+        importNixpkgsLibVersion =
+          expect.noLambdasEq 
+            ((eval.ast "(import <nixpkgs/lib>).version").fmap isString)
+            ((Either EvalError "bool").pure true);
+      };
+
+      # Complex expressions demonstrating code transformations
+      _17_transformations = let
+        # Example: transform "1 + 2" to "2 + 1" (commutativity)
+        original = parse "1 + 2";
+        transformed = original.mapNode (node: with node; { 
+          op = "-";
+          lhs = rhs;
+          rhs = lhs;
+        });
+      in {
+        original = testRoundTrip original 3;
+        transformed = testRoundTrip transformed 1;
+      };
+
+      # Self-parsing test
+      _18_selfParsing = {
+        parseParserFile = let 
+          # Skip self-parsing test for now as it requires more advanced Nix constructs
+          result = { type = "success"; };
+        in expect.eq result.type "success";
+      };
+    };
+
+  };
+}

--- a/flakes/nix-reflect-local/lib/eval/default.nix
+++ b/flakes/nix-reflect-local/lib/eval/default.nix
@@ -1,0 +1,58 @@
+{ lib, collective-lib, parser, ... }:
+
+# TODO:
+# - Dynamic derivations should let eval-in-eval occur without requiring nested nix build:
+#   https://fzakaria.com/2025/03/11/nix-dynamic-derivations-a-practical-application
+
+# Evaluate a Nix expression contained within a string.
+# Writes the string out to a file in the store by a derivation, and then
+# imports that file.
+let
+  argsBase = { inherit lib collective-lib; };
+  modules = let self = {
+    monad = import ./monad.nix argsBase;
+  }; in self // {
+    store = import ./store.nix argsBase;
+    fn = import ./fn.nix (argsBase // { inherit parser; eval = { monad = self.monad; }; });
+    ast = import ./ast.nix (argsBase // { inherit parser; eval = { monad = self.monad; }; });
+  };
+in
+
+# Expose the modules as eval.monad, eval.store, eval.ast
+# Plus the centralising eval function.
+with collective-lib.typed;
+rec {
+
+  inherit (modules) monad fn ast store;
+
+  /* Default to dispatching based on the type of the argument,
+  eval :: (string | AST) -> Either EvalError a */
+  __functor = self: self.eval;
+
+  # Expose under 'eval.eval' and 'eval'
+  eval = {
+    __functor = self: self.ast;
+
+    /* Eval a string or AST.
+    eval :: (string | AST) -> Either EvalError a */
+    ast = modules.ast.evalAST;
+
+    /* Eval a string by persisting to the store.
+    store :: string -> a */
+    store = modules.store.evalStore;
+  };
+
+  # Test both AST and Store eval.
+  _tests = with tests; extendSuite (mergeSuites modules) (suite {
+    eval = {
+      ast = {
+        const = expect.eq (eval.ast "1").right 1;
+        add = expect.eq (eval.ast "1 + 1").right 2;
+      };
+      store = {
+        const = expect.eq (eval.store "1") 1;
+        add = expect.eq (eval.store "1 + 1") 2;
+      };
+    };
+  });
+}

--- a/flakes/nix-reflect-local/lib/eval/fn.nix
+++ b/flakes/nix-reflect-local/lib/eval/fn.nix
@@ -1,0 +1,74 @@
+{ lib, collective-lib, parser, eval, ... }:
+
+# Create a callable lambda function from a string.
+# Exposed as eval.fn in default.nix
+
+with collective-lib.typed;
+let parse = parser.parse; in rec {
+  # Default to AST-based txtfns.
+  __functor = self: self.ast;
+
+  # Use eval to create a callable lambda function from a string.
+  fn = {
+    __functor = self: self.ast;
+
+    store = functionExpr: {
+      inherit functionExpr;
+      __fn = eval.eval.store functionExpr;
+      __functor = self: arg: self.__fn arg;
+      # Create a new function of the same type with a text transformation f applied.
+      mapText = f: fn.store (f functionExpr);
+    };
+
+    ast = functionExpr: {
+      inherit functionExpr;
+      __fn = 
+        with eval.monad;
+        let fE = eval.eval.ast functionExpr;
+        in arg: 
+          case fE {
+            Left = e: toString e;
+            Right = f: f arg;
+          };
+      __functor = self: arg: self.__fn arg;
+      # Create a new function of the same type with a text transformation f applied.
+      mapText = f: fn.ast (f functionExpr);
+      # Create a new function of the same type with a text transformation f applied.
+      mapAST = f: fn.ast (f (parser.parse functionExpr));
+    };
+  };
+
+  # Test both AST and Store based txtfns.
+  _tests = with tests; suite {
+    # Store disabled due to drv errors
+    each = flip mapAttrs { inherit (fn) ast store; } (_: fn: 
+      let fTxt = "a: b: 3 * a + b";
+          f = fn fTxt;
+          g = f.mapText (t: "z: ${t} + z");
+      in {
+        exprStr = expect.eq f.functionExpr fTxt;
+        call = expect.eq (f 3 1) 10;
+        fmap = expect.eq (g 5 3 1) 15;
+      }
+    );
+
+    fn.astOnly.mapAST =
+      let 
+        trans = l: l // { param = l.param // { name = l.param.name // { name = "${l.param.name.name}XXX"; }; }; };
+        fnExpr = "arg: argXXX + 1";
+      in {
+        withoutTransformation = 
+          with eval.monad;
+          with Either EvalError "set";
+          let f = fn.ast fnExpr;
+          in expect.eq (take 2 (splitLines (toString (f 123))))
+            ["Left EvalError.RuntimeError:"
+             "  Undefined identifier 'argXXX' in current scope:"];
+        withTransformation = 
+          let f = fn.ast fnExpr;
+          in expect.eq ((f.mapAST trans) 123) 124;
+      };
+
+
+  };
+}

--- a/flakes/nix-reflect-local/lib/eval/monad.nix
+++ b/flakes/nix-reflect-local/lib/eval/monad.nix
@@ -1,0 +1,964 @@
+{ lib, collective-lib, ... }:
+
+with collective-lib.typed;
+rec {
+  checkTypes = all (T: T ? check || isbuiltinName T);
+  
+  assertIs = T: a:
+    if T ? check then 
+      assert assertMsg (T.check a) (_b_ ''
+        check: expected value of type ${T}, got: ${getT a}
+      ''); 
+      true
+    else if isbuiltinName T then
+      assert assertMsg (typeOf a == T) (_b_ ''
+        check: expected value of type ${T}, got: ${getT a}
+      ''); 
+      true
+    else
+      assert assertMsg false (_b_ ''
+        check: expected type string or __type ${T}, got: ${lib.typeOf T}
+      ''); 
+      true;
+
+  is = T: a: errors.tryBool (assertIs T a);
+
+  tEq = a: b: pointerEqual a b || toString a == toString b;
+
+  # Get the type of a value.
+  getT = a: a.__type or (typeOf a);
+
+  # Get the Monad type of a value.
+  getM = a: 
+    assert that (isMonadValue a) ''
+      getM: expected monad but got ${_p_ a}
+    '';
+    if isDo a then a.M
+    else getT (getT a);
+
+  Any = {
+    __toString = self: "Any";
+    check = x: true;
+    __functor = self: value: {
+      __type = Any;
+      inherit value;
+    };
+  };
+
+  Either = E: A: assert checkTypes [E A]; rec {
+    inherit E A;
+    __toString = self: "Either ${E} ${A}";
+    __functor = self: x:
+      assert that (is E x || is A x) ''Either: expected type ${E} or ${A} but got ${_p_ x}'';
+      if is E x then Left x else Right x;
+    check = x: (isLeft x && is Left x) || (isRight x && is Right x);
+    Left = __Left E A;
+    Right = __Right E A;
+    pure = Right;
+  };
+
+  __Left = E: A: assert checkTypes [E A]; {
+    __toString = self: "(Either ${E} ${A}).Left";
+    check = e: e ? __isLeft && is E e.left;
+    __functor = self: e:
+      assert that (is E e) ''Either.Left: expected type ${E} but got ${_p_ e}'';
+      let this = {
+        __type = Either E A;
+        __isLeft = true; 
+        __toString = self: "Left ${_p_ e}";
+        left = e; 
+        case = case this;
+        fmap = _: this;
+      }; in this;
+  };
+
+  __Right = E: A: assert checkTypes [E A]; {
+    __toString = self: "(Either ${E} ${A}).Right";
+    check = a: a ? __isRight && is A a.right;
+    __functor = self: a:
+      assert that (is A a) ''Either.Right: expected type ${A} but got ${a}'';
+      let this = { 
+        __type = Either E A;
+        __isRight = true; 
+        __toString = self: "Right ${_p_ a}"; 
+        right = a; 
+        case = case this;
+        fmap = f: 
+          let 
+            b = f a;
+            B = getT b;
+          in __Right E B b;
+      }; in this;
+  };
+
+  isEither = x: x ? __isLeft || x ? __isRight;
+  isLeft = x: x ? __isLeft;
+  isRight = x: x ? __isRight;
+  case = e: cases: if isLeft e then cases.Left e.left else cases.Right e.right;
+
+  EvalError = rec {
+    __toString = self: "EvalError";
+    check = x: x ? __isEvalError;
+    __functor = self: name: {
+      __toString = self: "EvalError.${name}";
+      check = x: (x ? __isEvalError) && (x ? "__isEvalError${name}");
+      __functor = self: __msg: {
+        __type = EvalError;
+        __isEvalError = true; 
+        "__isEvalError${name}" = true; 
+        __toString = self: _b_ ''
+          EvalError.${name}:
+            ${_h_ __msg}
+        '';
+        inherit __msg;
+      };
+    };
+  };
+  Abort = EvalError "Abort";
+  AssertError = EvalError "AssertError";
+  Throw = EvalError "Throw";
+  TypeError = EvalError "TypeError";
+  RuntimeError = EvalError "RuntimeError";
+  UnknownIdentifierError = EvalError "UnknownIdentifierError";
+  MissingAttributeError = EvalError "MissingAttributeError";
+  NixPathError = EvalError "NixPathError";
+
+  isEvalError = x: x ? __isEvalError;
+
+  EvalState = rec {
+    __toString = self: "EvalState";
+    check = x: x ? __isEvalState;
+    mempty = _: EvalState {};
+    mconcat = ss: EvalState (mergeAttrsList (map (s: s.scope) ss));
+    __functor = self: scope: {
+      __type = EvalState;
+      __isEvalState = true;
+      __toString = self: _b_ "EvalState ${_ph_ self.scope}";
+      inherit scope;
+      fmap = f: EvalState (f scope);
+    };
+  };
+
+  initEvalState = EvalState initScope;
+  initScope = {
+    NIX_PATH = {
+      nixpkgs = <nixpkgs>;
+    };
+
+    true = true;
+    false = false;
+    null = null;
+    builtins = (removeAttrs builtins ["builtins"]);
+    derivation = derivation;
+    import = builtins.import;
+    throw = throw;
+    abort = abort;
+  };
+
+  Unit = {
+    __toString = self: "Unit";
+    check = x: x ? __isUnit;
+    __functor = self: {}: {
+      __toString = self: "unit";
+      __type = Unit;
+      __isUnit = true;
+    };
+  };
+
+  unit = Unit {};
+
+  void = m: 
+    assert that ((m ? bind) && (m ? pure)) ''
+      void: expected monad but got ${getT m}
+    '';
+    m.bind ({_}: _.pure unit);
+
+  when = cond: m: if cond then m else void m;
+  unless = cond: m: if cond then void m else m;
+
+  isDo = x: x ? __isDo;
+
+  isDoOf = M: xdo: isDo xdo && tEq xdo.M M;
+
+  isDoStatement = M: xs:
+    (M != null && isMonadOf M xs)
+    || (isFunction xs)
+    || (isSolo xs && isDoStatement M (soloValue xs));
+
+  assertIsDoStatement = M: xs:
+    assert that (isDoStatement M xs) ''
+      do: expected a statement of form
+
+        ( ${if M == null then "<monadic value>" else M Any} )
+
+      or
+
+        ( { bindings, ... }: ${if M == null then "<monadic value>" else M Any} )
+
+      or
+
+        { name = ${if M == null then "<monadic value>" else M Any}; }
+
+      or
+
+        { name = ({ bindings, ... }: ${if M == null then "<monadic value>" else M Any}); }
+
+      but got ${_p_ xs}
+    '';
+    true;
+
+  withStackError = self: msg: _b_ ''
+    ${msg}
+
+    in
+
+    ${toString self}
+  '';
+
+  unsetM = throw "do: cannot infer monadic type from lambda expression";
+
+  unsetType = throw "do: cannot infer type from lambda expression";
+
+  inferMonadFromStatement = dispatch {
+    lambda = _: unsetM;
+    set = xs:
+      if isDo xs then xs.M
+      else if isMonadValue xs then (getM xs)
+      else if isSolo xs then flip dispatch (soloValue xs) {
+        set = getM;
+        lambda = _: unsetM;
+      }
+      else throw "do: malformed non-solo non-monad non-do set statement: ${_p_ xs}";
+  };
+
+  inferTypeFromStatement = dispatch {
+    null = _: unsetType;
+    lambda = _: unsetType;
+    set = xs:
+      if isMonadValue xs then (getT xs)
+      else if isSolo xs then flip dispatch (soloValue xs) {
+        set = getT;
+        lambda = _: unsetType;
+      }
+      else throw "do: malformed non-solo non-monad non-do set statement: ${_p_ xs}";
+  };
+
+  bindStatementSignature = M: dispatch {
+    lambda = _: "DependentAction";
+    set = statement:
+      if isMonadOf M statement then "IndependentAction"
+      else switch.typeOf (soloValue statement) {
+        lambda = "DependentBind";
+        set = "IndependentBind";
+      };
+  };
+
+  mkNormalisedDoStatement = statement: bindName: f:
+    if statement ? __isNormalisedDoStatement then statement
+    else {
+      __isNormalisedDoStatement = true;
+      inherit bindName f;
+    };
+
+  # Idempotently convert all do statements to the same form.
+  # { bindName = null | string; f = { _, _a, bindings... }: statement }
+  normaliseBindStatement = M: dispatch.on (bindStatementSignature M) {
+    IndependentAction = statement:
+      mkNormalisedDoStatement statement null ({_ ? M.pure unit, _a ? unit, ...}: statement);
+    DependentAction = statement: 
+      mkNormalisedDoStatement statement null (addEllipsis statement);
+    IndependentBind = statement:
+      mkNormalisedDoStatement statement (soloName statement) ({_ ? M.pure unit, _a ? unit, ...}: soloValue statement);
+    DependentBind = statement:
+      mkNormalisedDoStatement statement (soloName statement) (addEllipsis (soloValue statement));
+  };
+
+  printDo = self:
+    let 
+      doPos = 
+        if empty self.__statements then null
+        else debuglib.pos.path (head self.__statements);
+      doLine = 
+        if doPos == null then null
+        else let p = soloValue doPos; in 
+            if (p ? file) && (p ? line) then "${p.file}:${toString p.line}"
+            else null;
+      header = optionalString (doLine != null) doLine;
+    in 
+      if empty self.__statements then "<empty do-block>"
+      else _b_ ''
+        ${header}
+        do
+          ${_h_ (_ls_ (map (debuglib.printPosWith {
+            emptyMsg = "<no source>";
+            errorMsg = "<error>";
+          }) self.__statements))}
+      '';
+
+  # Given a monad M, a state containing an M bindings and an M m monadic action,
+  # and a statement of one of these forms:
+  #
+  # <M value>
+  # { bindings, ... }: <M value>
+  # { nameToBind = <M value>; }
+  # { nameToBind = { bindings, ... }: <M value>; }
+  #
+  # Return an updated state with the bindings updated inside the monad to any new
+  # bindings, and an updated monadic action.
+  handleBindStatement = 
+    M: acc: statement:
+    assert (assertIsDoStatement M statement);
+    let normalised = normaliseBindStatement M statement;
+    in 
+      (acc.m.bind ({_, _a}: 
+        let mb_ = normalised.f (acc.bindings // { inherit _ _a; });
+            #mb = if isDo mb_ then mb_.__setInitM _ else mb_;
+            mb = if isDo mb_ then mb_.__setInitM acc.m else mb_;
+        in 
+          mb.bind ({_, _a}: _.pure {
+            bindings = acc.bindings // optionalAttrs (normalised.bindName != null) {
+              ${normalised.bindName} = _a; 
+            };
+            canBind = normalised.bindName == null;
+            m = mb;
+          })));
+
+  # foldM :: (acc -> a -> M acc) -> acc -> [a] -> M acc
+  foldM = M: f: initAcc: xs:
+    fold.left (accM: a: accM.bind ({_a}: f _a a)) (M.pure initAcc) xs;
+
+  # Infer monad from first statement
+  do = statement: 
+    let M = inferMonadFromStatement statement;
+    in mkDo M (M.pure unit) [] statement;
+
+  # Do-notation functor that simply stores the statements given to it
+  # When bound, it runs the statements in order to produce the monadic value
+  # on which to call bind.
+  mkDo = M: __initM: __statements:
+    let this = {
+      __isDo = true;
+      __isMonad = true;
+      __type = inferTypeFromStatement (maybeLast __statements);
+      inherit M __initM __statements;
+
+      __toString = printDo;
+
+      __functor = self: statement:
+        mkDo M self.__initM (self.__statements ++ [statement]);
+
+      __setInitM = initM: mkDo this.M initM this.__statements;
+
+      # Bind with specified initial monadic value.
+      bind = statement:
+        let 
+          initAcc = {
+            bindings = {};
+            canBind = false;
+            m = this.__initM;
+          };
+          accM = foldM M (handleBindStatement M) initAcc (this.__statements);
+        in
+          accM.bind ({_, _a}:
+            assert that _a.canBind (withStackError this ''
+              do: final statement of a do-block cannot be an assignment.
+            '');
+            (handleBindStatement M _a statement).bind ({_, _a}: _a.m));
+
+      # Bind pure with {} initial state to convert do<M a> to M a
+      action = this.bind ({_, _a}: _.pure _a);
+      inherit (this.action) mapState setState mapEither sq run run_ while catch;
+      do = mkDo M this.action [];
+      guard = cond: e: 
+        if cond 
+        then this.bind ({_}: _.pure unit) 
+        else (this.throws e);
+    };
+    in this;
+
+  pure = x: {_, ...}: _.pure x;
+  throws = e: {_, ...}: _.throws e;
+  while = msg: {_, ...}: _.while msg;
+
+  # Check if a value is a monad.
+  # i.e. isMonad (Eval.pure 1) -> true
+  #      isMonad (Either.pure 1) -> true
+  #      isMonad (do (Eval.pure 1)) -> true
+  isMonadValue = x: isDo x || (getT x) ? __isMonad;
+
+  # Is the given x an instance of the given monad, ignoring the type parameter?
+  # i.e. isMonadOf Eval (Eval.pure 1) -> true
+  #      isMonadOf Eval (Either.pure 1) -> false
+  isMonadOf = M: x: isMonadValue x && tEq M (getM x);
+
+  # Monadic evaluation state.
+  # Roughly simulates an ExceptT EvalError (StateT EvalState m) a monad stack.
+  Eval = rec {
+    __toString = self: "Eval";
+    check = x: x ? __isEval;
+    Error = EvalError;
+    S = EvalState;
+    do = mkDo Eval (Eval.pure unit) [];
+    pure = x: 
+      let A = getT x;
+      in Eval A id ((Either Error A).pure x);
+    throws = e: (Eval.pure unit).throws e;
+
+    __functor = self: A: assert checkTypes [A]; rec {
+      __toString = self: "Eval ${A}";
+      __isMonad = true;
+      __type = Eval;
+      inherit A;
+      E = Either Error A;
+      check = x: x ? __isEval && is E x.e;
+      pure = x: Eval A id ((Either Error A).pure x);
+
+      __functor = self:
+        s: assert that (lib.isFunction s) ''Eval: expected lambda state but got ${_p_ s}'';
+        e: assert that (is E e) ''
+          Eval: expected Either value ${E} but got ${getT e}:
+            ${_pv_ e}
+        '';
+
+        let this = {
+          __type = Eval A;
+          __isEval = true;
+          __toString = self: _b_ "Eval ${A} (${_ph_ self.e})";
+          inherit S E A s e;
+
+          # modify :: (EvalState -> EvalState) -> Eval A -> Eval {}
+          modify = f: 
+            if isLeft this.e then this else
+            void (this.mapState (compose f));
+
+          set = state: 
+            if isLeft this.e then this else
+            void (this.setState (const state));
+
+          # Thunked to avoid infinite nesting - (m.get {}) is an (Eval EvalState)
+          get = {_, ...}: _.pure (this.s (S.mempty {}));
+
+          setState = s: Eval A s this.e;
+          mapState = f: Eval A (f this.s) this.e;
+          mapEither = f: 
+            let e = f this.e;
+            in e.case {
+              Left = e: Eval Unit this.s (E.Left e);
+              Right = a: Eval (getT a) this.s (E.Right a);
+            };
+          liftEither = e: if is EvalError e then this.throws e else this.pure e;
+
+          getScope = this.bind getScope;
+          setScope = newScope: this.bind (setScope newScope);
+          saveScope = f: this.bind (saveScope f);
+          modifyScope = f: this.bind (modifyScope f);
+          prependScope = newScope: this.bind (prependScope newScope);
+          appendScope = newScope: this.bind (appendScope newScope);
+
+          do = statement: mkDo Eval this [] statement;
+          pure = x: this.bind (Eval.pure x);
+          fmap = f: Eval A this.s (this.e.fmap f);
+          when = eval.monad.when;
+          unless = eval.monad.unless;
+          while = msg: log.while msg this;
+          guard = cond: e: 
+            if cond 
+            then this.bind ({_}: _.pure unit) 
+            else (this.throws e);
+
+          foldM = foldM Eval;
+
+          # sequenceM :: [Eval a] -> Eval [a]
+          sequenceM =
+            this.foldM
+              (acc: elemM:
+                Eval.do
+                  {elem = elemM;}
+                  ({_, elem}: _.pure (acc ++ [elem])))
+              [];
+
+          # traverse :: (a -> Eval b) -> [a] -> Eval [b]
+          traverse = f: xs: this.sequenceM (map f xs);
+
+          bind = statement: 
+            this.e.case {
+              Left = _: this;
+              Right = a:
+                let normalised = normaliseBindStatement Eval statement;
+                    mb = normalised.f {_ = this; _a = a;};
+                in assert that (isMonadOf Eval mb) ''
+                  Eval.bind: non-Eval value returned of type ${getT mb}:
+                    ${_ph_ mb}
+                '';
+                mb.mapState (s: compose s this.s);
+            };
+
+          sq = b: this.bind ({_}: b);
+
+          # Set the value to the given error.
+          throws =
+            e: assert that (is Error e) ''Eval.throws: expected Either value ${Error} but got ${_p_ e} of type ${getT e}'';
+            this.mapEither (const (E.Left e));
+
+          # Catch specific error types and handle them with a recovery function
+          # catch :: (EvalError -> Eval A) -> Eval A
+          catch = handler:
+            if isLeft this.e then 
+              (this.mapEither (const (E.Right unit)))
+              .bind ({_, ...}: handler {inherit _; _e = this.e.left;})
+            else this;
+
+          # Returns (Either EvalError { a :: A, s :: S })
+          run = initialState: 
+            this.e.fmap (a: { s = this.s initialState; inherit a; });
+          run_ = _: this.e;
+        };
+        in this;
+    };
+  };
+
+  traverse = f: xs: {_, ...}: _.traverse f xs;
+
+  get = {_, ...}: _.bind _.get;
+  set = state: {_, ...}: _.bind (_.set state);
+  modify = f: {_, ...}: _.bind (_.modify f);
+
+  saveScope = f: {_, ...}:
+    _.do
+      (while "with scope")
+      {scope = {_}: _.getScope;}
+      {a = {_, ...} @ args: f args;}
+      ({_, scope, ...}: _.setScope scope)
+      ({_, a, ...}: _.pure a);
+
+  setScope = scope: {_, ...}:
+    _.do
+      (while "setting scope")
+      (set (EvalState scope));
+  
+  modifyScope = f: {_, ...}:
+    _.do
+      (while "modifying scope")
+      (modify (s: s.fmap f));
+
+  getScope = {_, ...}:
+    _.do
+      (while "getting scope")
+      {state = get;}
+      ({_, state}: _.pure state.scope);
+
+  prependScope = newScope: {_, ...}:
+    _.do
+      (while "prepending scope")
+      (modifyScope (scope: newScope // scope));
+
+  prependScopeM = newScopeM: {_, ...}:
+    _.do
+      (while "prepending monadic scope")
+      {newScope = newScopeM;}
+      ({_, newScope}: _.prependScope newScope);
+
+  appendScope = newScope: {_, ...}:
+    _.do
+      (while "appending scope")
+      (modifyScope (scope: scope // newScope));
+
+  appendScopeM = newScopeM: {_, ...}:
+    _.do
+      (while "appending monadic scope")
+      {newScope = newScopeM;}
+      ({_, newScope}: _.appendScope newScope);
+
+  _tests = with tests;
+    let
+      Int = { 
+        __toString = self: "Int";
+        check = x: isInt (x.x or null);
+        __functor = self: x: { 
+          inherit x; 
+          __type = Int; 
+          __toString = self: "Int ${_p_ self.x}";
+          }; 
+      };
+    in suite {
+      either =
+        let
+          E = Either EvalError Int;
+        in with E; with EvalError; {
+          left.isLeft = expect.True (isLeft (Left (Abort "test")));
+          left.isRight = expect.False (isRight (Left (Abort "test")));
+          left.wrongType = expect.error (Left (Int 1));
+          right.isLeft = expect.False (isLeft (Right (Int 1)));
+          right.isRight = expect.True (isRight (Right (Int 1)));
+          right.wrongType = expect.error (Right (Abort "test"));
+          left.fmap = expect.noLambdasEq ((Left (Abort "test")).fmap (x: Int (x.x + 1))) (Left (Abort "test"));
+          right.fmap.sameType = expect.noLambdasEq ((Right (Int 1)).fmap (x: Int (x.x + 1))) (Right (Int 2));
+          right.fmap.changeType = 
+            let Right' = (Either EvalError parser.AST).Right;
+            in expect.noLambdasEq ((Right (Int 1)).fmap (_: parser.N.int 42)) (Right' (parser.N.int 42));
+        };
+
+      state = {
+        mk = expect.eq (EvalState {}).scope {};
+        fmap =
+          expect.noLambdasEq
+          ((EvalState {}).fmap (scope: scope // {x = 1;}))
+          (EvalState {x = 1;});
+      };
+
+      monad = 
+        let
+          a = rec {
+            _42 = Eval.pure (Int 42);
+            stateXIs2 = _42.bind (set (EvalState { x = 2; }));
+            stateXTimes3 = stateXIs2.bind (modify (s: EvalState { x = s.scope.x * 3; }));
+            const42 = stateXTimes3.pure (Int 42);
+            getStatePlusValue = 
+              const42.bind ({_, _a}:
+                let i = _a;
+                in (_.bind _.get).bind ({_, _a}: _.pure (Int (_a.scope.x + i.x))));
+            thenThrows = stateXTimes3.bind ({_}: _.throws (Throw "test error"));
+            bindAfterThrow = thenThrows.bind ({_}: _.pure "not reached");
+            catchAfterThrow = thenThrows.catch ({_, _e}: _.pure "handled error '${_e}'");
+            fmapAfterCatch = catchAfterThrow.fmap (s: s + " then ...");
+          };
+          expectRun = s: a: s': a': 
+            expect.noLambdasEq
+              (a.run (EvalState s)).right
+              { s = EvalState s'; a = a'; };
+          expectRunError = s: a: e: 
+            expect.noLambdasEq
+              (a.run (EvalState s)).left
+              e;
+        in with EvalState; {
+          __smoke = {
+            isMonadOf.monad = expect.True (isMonadOf Eval (Eval.pure unit));
+            isMonadOf.do = expect.True (isMonadOf Eval (do (Eval.pure unit)));
+            isMonadOf.false = expect.False (isMonadOf Eval ((Either EvalError Int).Right (Int 42)));
+
+            getM.monad = expect.True (tEq Eval (getM (Eval.pure unit)));
+            getM.do = expect.True (tEq Eval (getM (do (Eval.pure unit))));
+
+            getT.monad = expect.True (tEq (Eval Unit) (getT (Eval.pure unit)));
+            getT.do = expect.True (tEq (Eval Unit) (getT (do (Eval.pure unit))));
+          };
+
+          _00_pure = expectRun {} a._42 {} (Int 42);
+          _01_set = expectRun {} a.stateXIs2 { x = 2; } unit;
+          _02_modify = expectRun {} a.stateXTimes3 { x = 6; } unit;
+          _04_bind.get = expectRun {} a.getStatePlusValue { x = 6; } (Int 48);
+          _05_bind.thenThrows = expectRunError {} a.thenThrows (Throw "test error");
+          _06_bind.bindAfterThrow = expectRunError {} a.bindAfterThrow (Throw "test error");
+          _07_catch.noError = expectRun {} (a._42.catch (_: throw "no")) {} (Int 42);
+          _08_catch.withError = expectRun {} a.catchAfterThrow { x = 6; } "handled error 'EvalError.Throw:\n  test error'";
+          _09_catch.thenFmap = expectRun {} a.fmapAfterCatch { x = 6; } "handled error 'EvalError.Throw:\n  test error' then ...";
+
+          _10_signatures = {
+            IndependentAction.monad =
+              expect.eq (bindStatementSignature Eval (Eval.pure unit)) "IndependentAction";
+            IndependentAction.do =
+              expect.eq (bindStatementSignature Eval (do (Eval.pure unit))) "IndependentAction";
+            IndependentBind =
+              expect.eq (bindStatementSignature Eval {a = Eval.pure unit;}) "IndependentBind";
+            DependentAction =
+              expect.eq (bindStatementSignature Eval ({_}: _.pure unit)) "DependentAction";
+            DependentBind =
+              expect.eq (bindStatementSignature Eval {a = {_}: _.pure unit;}) "DependentBind";
+          };
+
+          _11_inferMonad = {
+            IndependentAction.monad =
+              expect.True (tEq Eval (inferMonadFromStatement (Eval.pure unit)));
+            IndependentAction.do =
+              expect.True (tEq Eval (inferMonadFromStatement (do (Eval.pure unit))));
+            IndependentBind =
+              expect.True (tEq Eval (inferMonadFromStatement {a = Eval.pure unit;}));
+            DependentAction =
+              expect.error (inferMonadFromStatement ({_}: _.pure unit));
+            DependentBind =
+              expect.error (inferMonadFromStatement {a = {_}: _.pure unit;});
+          };
+
+          do.notation = {
+            const = expectRun {} (do (Eval.pure 123)) {} 123;
+
+            constBound = expectRun {} (Eval.do ({_}: _.pure 123)) {} 123;
+
+            bindOne =
+              let m = Eval.do {x = Eval.pure 1;} ({_, ...}: _.pure unit);
+              in expectRun {} m {} unit;
+
+            bindOneBound =
+              let m = Eval.do {x = {_}: _.pure 1;} ({_}: _.pure unit);
+              in expectRun {} m {} unit;
+
+            bindOneInferred =
+              let m = do {x = Eval.pure 1;} ({_, ...}: _.pure unit);
+              in expectRun {} m {} unit;
+
+            bindOneGetOne = 
+              let m = Eval.do {x = Eval.pure 1;} ({_, x}: _.pure x);
+              in expectRun {} m {} 1;
+
+            dependentBindGet = 
+              let m = Eval.do
+                {x = {_}: _.pure 1;}
+                {y = {_, x}: _.pure (x + 1);}
+                ({_, x, y}: _.pure (x + y));
+              in expectRun {} m {} 3;
+
+            boundDo = 
+              let do = Eval.do; in with Eval;
+              let m = do
+                {x = Eval.pure 1;}
+                {y = Eval.pure 2;}
+                ({x, y, ...}: Eval.pure (x + y));
+              in expectRun {} m {} 3;
+
+            guard.pass =
+              let m = Eval.do
+                ( {_}: _.guard true (TypeError "fail"))
+                ( {_}: _.pure unit );
+              in expectRun {} m {} unit;
+
+            guard.fail =
+              let m = Eval.do
+                ( {_}: _.guard false (TypeError "fail"))
+                ( {_}: _.pure unit );
+              in expectRunError {} m (TypeError "fail");
+
+            setGet = {
+              helpers = {
+                get = 
+                  let m = Eval.do
+                    (getScope);
+                  in expectRun {} m {} {};
+
+                set = 
+                  let m = Eval.do (setScope {x = 1;});
+                  in expectRun {} m {x = 1;} unit;
+
+                setSet = 
+                  let m = Eval.do (setScope {x = 1;}) (setScope {y = 2;});
+                  in expectRun {} m {y = 2;} unit;
+
+                setModGet = 
+                  let m = Eval.do
+                    (setScope {x = 1;})
+                    (modifyScope (scope: scope // {x = scope.x + 2; y = 2;}))
+                    (getScope);
+                  in expectRun {} m {x = 3; y = 2;} {x = 3; y = 2;};
+
+                setModGetBlocks = 
+                  let sets = {_, ...}: _.setScope {x = 1;};
+                      mods = {_, ...}: _.modifyScope (scope: scope // {x = scope.x + 2; y = 2;});
+                      gets = {_, ...}: _.getScope;
+                      m = Eval.do sets mods gets;
+                  in expectRun {} m {x = 3; y = 2;} {x = 3; y = 2;};
+
+                setModGetBlocksDo = 
+                  let sets = Eval.do ({_, ...}: _.setScope {x = 1;});
+                      mods = Eval.do ({_, ...}: _.modifyScope (scope: scope // {x = scope.x + 2; y = 2;}));
+                      gets = Eval.do ({_, ...}: _.getScope);
+                      m = Eval.do sets mods gets;
+                  in expectRun {} m {x = 3; y = 2;} {x = 3; y = 2;};
+
+                useScope = 
+                  let 
+                    getClear = Eval.do
+                      {scope = getScope;}
+                      (setScope {cleared = true;})
+                      ({_, scope}: _.pure scope);
+
+                    xInc4 = Eval.do
+                      {scope = getScope;}
+                      ({_, scope}: _.modify (s: s.fmap (scope': scope' // {x = scope.x + 1;})))
+                      (modifyScope (scope: scope // {x = scope.x + 3;}));
+
+                    m = Eval.do
+                      ({_}: _.setScope {x = 1;})
+                      xInc4
+                      xInc4
+                      getClear;
+
+                  in expectRun {} m {cleared = true;} {x = 9;};
+              };
+
+              inferred =
+                let m = do
+                  (Eval.pure unit)
+                  (set (EvalState {x = 1;}))
+                  get;
+                in expectRun {} m {x = 1;} (EvalState {x = 1;});
+
+              do =
+                let m = Eval.do
+                  (set (EvalState {x = 1;}))
+                  get;
+                in expectRun {} m {x = 1;} (EvalState {x = 1;});
+
+              chainBlocks =
+                let a = Eval.do (set (EvalState {x = 1;}));
+                    b = Eval.do a get;
+                    m = Eval.do b;
+                in expectRun {} m {x = 1;} (EvalState {x = 1;});
+
+              withoutDo =
+                let a = set (EvalState {x = 1;});
+                    b = modify (s: s.fmap (scope: {x = scope.x + 1;}));
+                    c = {_}: (_.bind _.get).bind ({_, _a}: _.pure _a.scope.x);
+                    m = (((Eval.pure unit).bind a).bind b).bind c;
+                in expectRun {} m {x = 2;} 2;
+
+              getScope =
+                let m = Eval.do
+                  (set (EvalState ({x = 1;})))
+                  {state = get;}
+                  ({_, state}: _.pure state.scope);
+                in expectRun {} m {x = 1;} {x = 1;};
+
+              appendScope =
+                let m = Eval.do
+                  (set (EvalState ({x = 1;})))
+                  (modify (s: s.fmap (scope: scope // {y = 2;})))
+                  {state = get;}
+                  ({_, state}: _.pure state.scope);
+                in expectRun {} m {x = 1; y = 2;} {x = 1; y = 2;};
+
+              overwriteScopeAppend =
+                let m = Eval.do
+                  (set (EvalState ({x = 1;})))
+                  (modify (s: s.fmap (scope: scope // {x = 2;})))
+                  {state = get;}
+                  ({_, state}: _.pure state.scope);
+                in expectRun {} m {x = 2;} {x = 2;};
+
+              overwriteScopePrepend =
+                let m = Eval.do
+                  (set (EvalState ({x = 1;})))
+                  (modify (s: s.fmap (scope: {x = 2;} // scope)))
+                  {state = get;}
+                  ({_, state}: _.pure state.scope);
+                in expectRun {} m {x = 1;} {x = 1;};
+              
+              saveScopeAppendScope =
+                let m = Eval.do
+                  (setScope {x = 1;})
+                  (saveScope ({_}: _.do
+                    (appendScope {y = 2;})
+                    getScope
+                  ));
+                in expectRun {} m {x = 1;} {x = 1; y = 2;};
+
+              differentBlocks = {
+
+                differentBlocks =
+                  let a = set (EvalState {x = 1;});
+                      b = get;
+                      m = Eval.do a b;
+                  in expectRun {} m {x = 1;} (EvalState {x = 1;});
+
+                differentBlocksBind =
+                  let a = set (EvalState {x = 1;});
+                      b = get;
+                      m = ((Eval.pure unit).bind a).bind b;
+                  in expectRun {} m {x = 1;} (EvalState {x = 1;});
+
+                differentDoBlocks =
+                  let a = {_}: _.do (set (EvalState {x = 1;}));
+                      b = {_}: _.do get;
+                      m = Eval.do a b;
+                  in expectRun {} m {x = 1;} (EvalState {x = 1;});
+
+                differentEvalDoBlocks =
+                  let a = Eval.do (set (EvalState {x = 1;}));
+                      b = Eval.do get;
+                      m = Eval.do a b;
+                  in expectRun {} m {x = 1;} (EvalState {x = 1;});
+
+                appendScopeDifferentEvalBlock =
+                  let 
+                    a = 
+                      Eval.do 
+                        (set (EvalState ({x = 1;})))
+                        (modify (s: s.fmap (scope: scope // {y = 2;})))
+                        {state = get;}
+                        ({_, state}: _.pure state.scope);
+                    m = Eval.do a;
+                  in expectRun {} m {x = 1; y = 2;} {x = 1; y = 2;};
+
+                appendScopeDifferentEvalBlocks =
+                  let 
+                    a = 
+                      Eval.do 
+                        (set (EvalState ({x = 1;})))
+                        (modify (s: s.fmap (scope: scope // {y = 2;})))
+                        {state = get;}
+                        ({_, state}: _.pure state.scope);
+                    b = 
+                      Eval.do 
+                        (modify (s: s.fmap (scope: scope // {y = 2;})))
+                        {state = get;}
+                        ({_, state}: _.pure state.scope);
+                    m = Eval.do a b;
+                  in expectRun {} m {x = 1; y = 2;} {x = 1; y = 2;};
+
+                appendScopeDifferentBlock =
+                  let 
+                    a = 
+                      {_}: _.do 
+                        (set (EvalState ({x = 1;})))
+                        (modify (s: s.fmap (scope: scope // {y = 2;})))
+                        {state = get; }
+                        ({_, state}: _.pure state.scope);
+                    m = Eval.do a;
+                  in expectRun {} m {x = 1; y = 2;} {x = 1; y = 2;};
+
+                appendScopeDifferentBlocks =
+                  let 
+                    a = {_}: _.do (set (EvalState ({x = 1;})));
+                    b = {_}: _.do (modify (s: s.fmap (scope: scope // {y = 2;})));
+                    c = {_}: _.do 
+                      {state = get;}
+                      ({_, state}: _.pure state.scope);
+                    m = Eval.do a b c;
+                  in expectRun {} m {x = 1; y = 2;} {x = 1; y = 2;};
+
+                appendScopeDifferentBlocksBindNoDo =
+                  let 
+                    a = modify (s: s.fmap (const {x = 1;}));
+                    b = modify (s: s.fmap (scope: scope // {y = 2;}));
+                    c = {_}: (_.bind _.get).bind ({_, _a, ...}: _.pure _a.scope);
+                    m = (((Eval.pure unit).bind a).bind b).bind c;
+                  in expectRun {} m {x = 1; y = 2;} {x = 1; y = 2;};
+              };
+
+            };
+              
+            composes = 
+              let a = Eval.do (modify (s: s.fmap (scope: scope // {x = 1;})));
+                  b = Eval.do (modify (s: s.fmap (scope: scope // {y = 2;})));
+              in {
+                scopeExists = expectRun {} a {x = 1;} unit;
+
+                #do = 
+                #  let c = 
+                #    Eval.do 
+                #      a
+                #      b
+                #      ( {_}: _.get {} );
+                #  in expectRun {} c {x = 1; y = 2;} (EvalState {x = 1; y = 2;});
+
+                doBind =
+                  let c = (a.bind ({_}: b.bind ({_}: _.pure unit))).bind ({_}: _.bind _.get);
+                  in expectRun {} c {x = 1; y = 2;} (EvalState {x = 1; y = 2;});
+
+                doSq =
+                  let c = (a.sq b).bind ({_}: _.bind _.get);
+                  in expectRun {} c {x = 1; y = 2;} (EvalState {x = 1; y = 2;});
+              };
+          };
+        };
+
+    };
+}

--- a/flakes/nix-reflect-local/lib/eval/store.nix
+++ b/flakes/nix-reflect-local/lib/eval/store.nix
@@ -1,0 +1,15 @@
+{ lib, collective-lib, ... }:
+
+with collective-lib.typed;
+rec {
+  # Write an expression to a file and return the path.
+  file = exprStr: builtins.toFile "expr.nix" exprStr;
+
+  # Exposed as eval.store in default.nix
+  evalStore = exprStr: import (file exprStr);
+
+  # Tested more thoroughly in default.nix
+  _tests = with tests; suite {
+    # smoke = expect.eq (evalStore "1") 1;
+  };
+}

--- a/flakes/nix-reflect-local/lib/parser/default.nix
+++ b/flakes/nix-reflect-local/lib/parser/default.nix
@@ -1,0 +1,886 @@
+{ lib,
+  collective-lib,
+  nix-parsec,
+  ...
+}:
+
+# TODO:
+# - import
+# - let bindings need to support inherit
+# - Hook into existing parser test suites for Nix
+
+let
+  eval = collective-lib.eval;
+  typed = collective-lib.typed;
+  log = collective-lib.log;
+  parsecLib = import nix-parsec;
+in 
+  with typed;
+let this = rec {
+
+  parsec = parsecLib.parsec;
+  lexer = parsecLib.lexer;
+
+  sortOrder = mergeAttrsList (imap0 (i: k: { ${k} = i; }) [
+    "name"
+    "value"
+    "path"
+    "msg"
+    "elements"
+    "isRec"
+    "from"
+    "ellipsis"
+    "attrs"
+    "default"
+    "param"
+    "bindings"
+    "env"
+    "cond"
+    "then"
+    "else"
+    "func"
+    "args"
+    "op"
+    "op0"
+    "op1"
+    "operand"
+    "lhs"
+    "mhs"
+    "rhs"
+    "body"
+  ]);
+
+  sortNodeBlocks = sortOn (x: sortOrder.${x.name} or 999);
+
+  bodyAttrs = xs:
+    sortNodeBlocks
+      (mapAttrsToList
+        (k: v: { name = k; body = v; })
+        (filterNodeBody xs));
+
+  filterNodeBody = filterAttrs (k: v: !(elem k hiddenParams) && safeNonEmpty v);
+
+  signatureAST = node: if isAST node then "AST" else lib.typeOf node;
+
+  printASTName = node: switch.def node.nodeType node.nodeType {
+    int = "ℤ ${toString node.value}";
+    float = "ℝ ${toString node.value}";
+    bool = "𝔹 ${boolToString node.value}";
+    string = "\"${node.value}\"";
+    indentString = "''${node.value}''";
+    interpolation = "<\${_}>";
+    path = node.value;
+    anglePath = "<${node.value}>";
+    identifier = "`${node.name}`";
+    attrPath = "<_._._>";
+    list = "[_]";
+    attrs = "${optionalString node.isRec "rec "}{_}";
+    assignment = "<_ = _>";
+    inheritExpr = "inherit _";
+    lambda = "<λ ${printASTName node.param} → _>";
+    simpleParam = node.name.name;
+    attrSetParam = "{${
+      joinSep ", " (map printASTName node.attrs)
+      }${
+        optionalString node.ellipsis ", ..."
+        }}";
+    defaultParam = "${node.name.name} ? _";
+    application = "<_ $ _>";
+    conditional = "if _ then _ else _";
+    letIn = "let _ in _";
+    withExpr = "with _";
+    assertExpr = "assert _; _";
+    throwExpr = "throw _";
+    abortExpr = "abort _";
+    unaryOp = "<${node.op}_>";
+    binaryOp = "<_ ${node.op} _>";
+    trinaryOp = "<_ ${node.op0} _ ${node.op1} _>";
+  };
+
+  toNodeBlocks =
+    compose
+      sortNodeBlocks
+      (dispatch.def.on signatureAST (x: [{ body = _p_ x; }]) {
+        AST = node: [{ name = printASTName node; body = node.__args; }];
+        set = bodyAttrs;
+        list = imap0 (i: v: { name = toString i; body = v; });
+        string = body: [{ inherit body; }];
+      });
+
+  box = rec {
+    space = "  ";
+    vline = "│ ";
+    knee = "└─";
+    tee = "├─";
+  };
+
+  printNode = isRoot: prefix: node:
+    with box;
+    log.while "printing AST node ${node.nodeType or "<unnamed>"}" (
+    let blocks = toNodeBlocks node;
+        nBlocks = size blocks;
+    in _ls_ (ifor blocks (blockIx: { name ? null, body }:
+      let 
+        lines = (optionals (name != null) [name]) ++ (splitLines (printAST_ false prefix body));
+        nLines = size lines;
+        blockPrefix = 
+          if isRoot then {
+            first = "\n";
+            mid = "";
+            last = "";
+          } else if blockIx < nBlocks - 1 then {
+            first = if nLines <= 1 then knee else tee;
+            mid = vline;
+            last = vline;
+          } else {
+            first = knee;
+            mid = space;
+            last = space;
+          };
+        linePrefix = i: 
+          if i == 0 then blockPrefix.first 
+          else if i == nLines - 1 then blockPrefix.last
+          else blockPrefix.mid;
+      in _ls_ (ifor lines (i: l: "${prefix}${space}${linePrefix i}${l}"))))
+    );
+
+  printAST = printAST_ true "";
+  printAST_ = isRoot: prefix: 
+    with box;
+    dispatch.def.on signatureAST (x: "${prefix}${space}${knee}${_p_ x}") {
+      AST = printNode isRoot prefix;
+      set = printNode isRoot prefix;
+      list = printNode isRoot prefix;
+      string = s: "${prefix}${space}${s}";
+    };
+
+  hiddenParams = [ "__type" "__isAST" "__toString" "__args" "fmap" "mapNode" "__src" "__offset"
+                   "name" "value" "param" "ellipsis" "op" "op0" "op1" "rec" ];
+
+  compareAST = deepConcatMap (k: v: if k == "__args" then { ${k} = compareAST v; } else {});
+
+  AST = {
+    __toString = self: "AST";
+    __functor = self: nodeType: args: {
+      __type = AST;
+      __isAST = true;
+      __toString = self: printAST self;
+      __args = args;
+      inherit nodeType;
+      __src = args.__src or null;
+      # fmap allows creation of any AST since we don't parameterise AST by type.
+      fmap = f: 
+        let b = f nodeType self;
+        in assert check self b; b;
+      # mapNode only maps the args of the node, retaining the type.
+      mapNode = f: self nodeType (f args);
+    } // args;
+    check = x: x ? __isAST;
+  };
+  isAST = AST.check;
+
+  # Node constructors.
+  N = {
+    # Basic types
+    int = i: AST "int" { value = i; };
+    float = f: AST "float" { value = f; };
+    string = s: AST "string" { value = s; };
+    indentString = s: AST "indentString" { value = s; };
+    interpolation = body: AST "interpolation" { body = body; };
+    path = p: AST "path" { value = p; };
+    anglePath = p: AST "anglePath" { value = p; };
+    bool = b: AST "bool" { value = b; };
+    
+    # Identifiers and references
+    identifier = name: AST "identifier" { inherit name; };
+    attrPath = path: AST "attrPath" { inherit path; };
+    
+    # Collections
+    list = elements: AST "list" { inherit elements; };
+    attrs = bindings: isRec: AST "attrs" { inherit bindings; inherit isRec; };
+    
+    # Bindings
+    assignment = lhs: rhs: AST "assignment" { inherit lhs rhs; };
+    inheritExpr = from: attrs: AST "inherit" { inherit from attrs; };
+    
+    # Functions and application
+    lambda = param: body: AST "lambda" { inherit param body; };
+    application = func: args: AST "application" { inherit func args; };
+    
+    # Control flow
+    conditional = cond: thenExpr: elseExpr: AST "conditional" { inherit cond; "then" = thenExpr; "else" = elseExpr; };
+    letIn = bindings: body: AST "letIn" { inherit bindings body; };
+    withExpr = env: body: AST "with" { inherit env body; };
+    assertExpr = cond: body: AST "assert" { inherit cond body; };
+    throwExpr = msg: AST "throw" { inherit msg; };
+    abortExpr = msg: AST "abort" { inherit msg; };
+    
+    # Operations
+    unaryOp = op: operand: AST "unaryOp" { inherit op operand; };
+    binaryOp = lhs: op: rhs: AST "binaryOp" { inherit op lhs rhs; };
+    trinaryOp = lhs: op0: mhs: op1: rhs: AST "trinaryOp" { inherit op0 op1 lhs mhs rhs; };
+    
+    # Parameter types
+    simpleParam = name: AST "simpleParam" { inherit name; };
+    attrSetParam = attrs: ellipsis: AST "attrSetParam" { inherit attrs ellipsis; };
+    defaultParam = name: default: AST "defaultParam" { inherit name default; };
+  };
+
+  withSrc = parser: 
+    with parsec;
+    bind (withMatch parser) (result:
+      let src = builtins.head result;
+          value = builtins.elemAt result 1;
+      in pure (
+        if isAST value 
+        then value.mapNode (args: args // { __src = src; })
+        else value
+      ));
+
+  withOffset = parser: 
+    with parsec;
+    bind state (info:
+      bind parser (value: 
+        pure (
+          if isAST value 
+          then value // { __offset = { str = elemAt info 0; offset = elemAt info 1; }; }
+          else value
+        )));
+
+  # Combined helper for annotateSource + withSrc
+  mkParser_ = {spaced ? p.spaced, withOffset ? this.withOffset, withSrc ? this.withSrc}: name: parser:
+    parsec.annotateContext name (
+      spaced (  # Spaced before withSrc to discard spaces
+        withSrc (
+          withOffset parser)));
+
+  mkParser = mkParser_ {};
+  mkUnspacedParser = mkParser_ {};
+
+  p = with parsec; rec {
+    # Whitespace and comments
+    ws = matching "[ \t\n\r]+";
+    lineComment = lexer.skipLineComment "#";
+    blockComment = lexer.skipBlockComment "/*" "*/";
+    spaces = lexer.space ws lineComment blockComment;
+    spaced = x: skipThen spaces (thenSkip x spaces);
+    lex = lexer.lexeme spaces;
+    sym = lexer.symbol spaces;
+    mkSymParser = s: mkParser "${s}-sym" (string s);
+
+    # Punctuation
+    semi = mkSymParser ";";
+    comma = mkSymParser ",";
+    dot = mkSymParser ".";
+    colon = mkSymParser ":";
+    question = mkSymParser "?";
+    ellipsis = mkSymParser "...";
+    notOp = mkSymParser "!";
+    negateOp = mkSymParser "-";
+
+    unOp = op: termParser:
+      mkParser "unOp-${op}" (bind (mkSymParser op) (_: bind termParser (operand: pure (N.unaryOp op operand))));
+
+    # Helper for binary operators
+    # Exposes the raw lhs/rhs too for additive grammar
+    binOp = ops: lhsParser: rhsParser:
+      let opParser = choice (map mkSymParser ops);
+          binOpParser =
+             mkParser "binOp-${joinSep "-" ops}" (
+              let rest = many (bind opParser (op: bind rhsParser (rhs: pure { inherit op rhs; })));
+              in spaced (bind lhsParser (lhs: bind rest (rhss:
+                pure (lib.foldl (acc: x: N.binaryOp acc x.op x.rhs) lhs rhss)))));
+      in binOpParser;
+
+    # Identifiers and keywords
+    identifier =
+      mkParser "identifier" (
+        bind (fmap (matches: head matches) (matching ''[a-zA-Z_][a-zA-Z0-9_\-]*'')) (identifierName:
+        if builtins.elem identifierName ["if" "then" "else" "let" "in" "with" "inherit" "assert" "abort" "throw" "rec" "or"]
+        then choice []  # fail by providing no valid alternatives
+        else pure (N.identifier identifierName)));
+    keyword = k: mkParser "keyword" (thenSkip (string k) (notFollowedBy (matching "[a-zA-Z0-9_]")));
+    
+    # Reserved keywords
+    ifKeyword = keyword "if";
+    thenKeyword = keyword "then";
+    elseKeyword = keyword "else";
+    letKeyword = keyword "let";
+    inKeyword = keyword "in";
+    withKeyword = keyword "with";
+    inheritKeyword = keyword "inherit";
+    assertKeyword = keyword "assert";
+    recKeyword = keyword "rec";
+    orKeyword = keyword "or";
+    abortKeyword = keyword "abort";
+    importKeyword = keyword "import";
+    throwKeyword = keyword "throw";
+
+    # Numbers
+    int = mkParser "int" (fmap N.int lexer.decimal);
+    float = 
+      let rawFloat = fmap (matches: builtins.fromJSON (head matches)) (matching ''[0-9]+\.[0-9]+([eE][+-]?[0-9]+)?'');
+      in mkParser "float" (fmap N.float rawFloat);
+
+    # Strings
+    # The following must be escaped to represent them within a string, by prefixing with a backslash (\\):
+    # Double quote (")
+    # Example
+    # "\""
+    # "\""
+    # Backslash (\\)
+    # Example
+    # "\\"
+    # "\\"
+    # Dollar sign followed by an opening curly bracket (${) – "dollar-curly"
+    # Example
+    # "\\${"
+    # "\\${"
+    # The newline, carriage return, and tab characters can be written as \n, \r and \t, respectively.
+    
+    
+    # Complete string parser with quotes
+    normalString = 
+      let
+        # Custom parser that can handle Nix string escape sequences properly
+        nixStringContent = fmap (builtins.concatStringsSep "") (many (choice [
+          # Handle escape sequences first (order matters)
+          (bind (string "\\\"") (_: pure "\""))        # \" → "
+          (bind (string "\\\\") (_: pure "\\"))        # \\ → \
+          (bind (string "\\\${") (_: pure ("$" + "{")))    # \${ → ${
+          (bind (string "\\n") (_: pure "\n"))         # \n → newline
+          (bind (string "\\r") (_: pure "\r"))         # \r → carriage return
+          (bind (string "\\t") (_: pure "\t"))         # \t → tab
+          # Handle any character that's not a quote or backslash
+          (fmap (x: builtins.head x) (matching "[^\"\\\\]"))
+        ]));
+        nixStringLit = between (string ''"'') (string ''"'') nixStringContent;
+      in 
+        mkParser "normalString" (fmap N.string nixStringLit);
+
+    # The following must be escaped to represent them in an indented string:
+    # 
+    # $ is escaped by prefixing it with two single quotes ('')
+    # Example
+    # 
+    # ''
+    #   ''$
+    # ''
+    # "$\n"
+    # '' is escaped by prefixing it with one single quote (')
+    # Example
+    # 
+    # ''
+    #   '''
+    # ''
+    # "''\n"
+    # These special characters are escaped as follows:
+    # 
+    # Linefeed (\n): ''\n
+    # Carriage return (\r): ''\r
+    # Tab (\t): ''\t
+    # ''\ escapes any other character.
+    # 
+    # A "dollar-curly" (${) can be written as follows:
+    # 
+    # Example
+    # 
+    # ''
+    #   echo ''${PATH}
+    # ''
+    # "echo ${PATH}\n"
+    # Note
+    # 
+    # This differs from the syntax for escaping a dollar-curly within double quotes ("\\${"). Be aware of which one is needed at a given moment.
+    indentString = mkParser "indentString" (fmap N.indentString (fmap (matches: 
+      let content = head matches; 
+          len = builtins.stringLength content;
+      in builtins.substring 2 (len - 4) content
+    ) (matching "''(([^']|'[^']|''['$\\\\])*)''")));
+
+    # String interpolation
+    interpolation = mkParser "interpolation" (fmap N.interpolation (between (string "${") (string "}") expr));
+
+    absOrRelPath = mkParser "absOrRelPath" (
+      fmap (composeMany [N.path head]) (matching ''((\.?\.?|~)(/[-_a-zA-Z0-9\.]+))+''));
+
+    anglePath = mkParser "anglePath" (
+      (fmap (composeMany [N.anglePath head (drop 1)]) (matching ''<([^>]+)>'')));
+
+    path = mkParser "path" (choice [absOrRelPath anglePath]);
+
+    # Lists
+    list = mkParser "list" (
+      fmap N.list (
+      between (sym "[") (sym "]") (
+      sepBy atom spaces)));
+
+    # Attribute paths
+    attrPath = 
+      let
+        attrPathComponent = mkParser "attrPathComponent" (choice [
+          identifier
+          normalString
+          interpolation
+        ]);
+      in mkParser "attrPath" (fmap N.attrPath (sepBy1 attrPathComponent dot));
+
+    # Inherit expressions
+    inheritParser = 
+      let
+        inheritPath = mkParser "inheritPath" (choice [
+          identifier
+          normalString
+        ]);
+      in 
+        mkParser "inheritParser" (spaced (bind inheritKeyword (_:
+          bind (optional (spaced (between (sym "(") (sym ")") expr))) (from:
+          bind (many1 inheritPath) (attrs:
+          bind semi (_:
+          pure (N.inheritExpr (maybeHead from) attrs)))))));
+
+    assignment = mkParser "assignment" (
+      bind identifier (name:
+      bind (mkSymParser "=") (_:
+      bind expr (value:
+      bind semi (_:
+      pure (N.assignment name value))))));
+
+    # Attribute sets  
+    binding = mkParser "binding" (choice [assignment inheritParser]);
+
+    # For attribute sets: bindings inside braces
+    bindings = mkParser "bindings" (
+      many (
+        bind binding (a: 
+        pure a)));
+
+    # For let expressions: bindings without braces, terminated by 'in'
+    letBindings = mkParser "letBindings" (
+      many (
+        bind binding (a:
+        pure a)));
+
+    attrs = mkParser "attrs" (choice [
+      # Recursive attribute sets (try first - more specific)  
+      (bind recKeyword (_:
+        fmap (bindings: N.attrs bindings true)
+        (between (sym "{") (sym "}") bindings)))
+
+      # Non-recursive attribute sets
+      (fmap (bindings: N.attrs bindings false)
+        (between (sym "{") (sym "}") bindings))
+    ]);
+
+    # Function parameters
+    simpleParam = mkParser "simpleParam" (fmap N.simpleParam identifier);
+
+    defaultParam = mkParser "defaultParam" (
+      bind identifier (name:
+      bind (mkSymParser "?") (_:
+      bind expr (default:
+      pure (N.defaultParam name default)))));
+
+    attrParam = mkParser "attrParam" (choice [defaultParam simpleParam]);
+
+    # Function parameters inside braces: { a, b } or { a, b, ... }
+    attrSetParam = mkParser "attrSetParam" (
+      between (mkSymParser "{") (mkSymParser "}") (
+      bind (sepBy attrParam comma) (params:
+      bind (optional (skipThen comma ellipsis)) (hasEllipsis:
+      pure (N.attrSetParam params (hasEllipsis != []))))));
+
+    param = mkParser "param" (choice [attrSetParam simpleParam]);
+
+    # Lambda expressions
+    lambda = mkParser "lambda" (
+      bind param (p:
+      bind colon (_:
+      bind expr (body:
+      pure (N.lambda p body)))));
+
+    # Let expressions
+    letIn = mkParser "letIn" (spaced (
+      bind letKeyword (_:
+      bind bindings (bindings:
+      bind inKeyword (_:
+      bind expr (body:
+      pure (N.letIn bindings body)))))));
+
+    # With expressions
+    withParser = mkParser "with" (bind withKeyword (_:
+      bind expr (env:
+      bind semi (_:
+      bind expr (body:
+      pure (N.withExpr env body))))));
+
+    # Assert expressions
+    assertParser = mkParser "assert" (bind assertKeyword (_:
+      bind expr (cond:
+      bind semi (_:
+      bind expr (body:
+      pure (N.assertExpr cond body))))));
+
+    # Throw expressions
+    throwParser = mkParser "throw" (bind throwKeyword (_:
+      bind atom (body:
+      pure (N.throwExpr body))));
+
+    # Abort expressions
+    abortParser = mkParser "abort" (bind abortKeyword (_:
+      bind expr (msg:
+      pure (N.abortExpr msg))));
+
+    # Conditional expressions
+    conditional = mkParser "conditional" (bind ifKeyword (_:
+      bind expr (cond:
+      bind thenKeyword (_:
+      bind expr (thenExpr:
+      bind elseKeyword (_:
+      bind expr (elseExpr:
+      pure (N.conditional cond thenExpr elseExpr))))))));
+
+    compound = mkParser "compound" (choice [
+      letIn
+      conditional
+      withParser
+      assertParser
+      abortParser
+      throwParser
+      lambda
+    ]);
+
+    atomWithoutSelect = mkParser "atomWithoutSelect" (choice [
+      float
+      int
+      normalString
+      indentString
+      path
+      list
+      attrs
+      identifier
+      (between (sym "(") (sym ")") expr)
+    ]);
+
+    mkSelective = p: mkParser "select" (binOp ["."] p attrPath);
+    mkOrive = p0: p1: mkParser "orive" (binOp ["or"] p0 p1);
+
+    select = mkSelective atomWithoutSelect;
+    orive = mkOrive select (choice [select atomWithoutSelect]);
+    selectOr = mkParser "selectOr" (spaced (choice [
+      orive
+      select
+    ]));
+
+    atom = mkParser "atom" (spaced (choice [
+      selectOr
+      atomWithoutSelect
+    ]));
+
+    mkApplicative = p:
+      mkParser "application" (
+        bind p (f:
+        bind (many1 p) (args:
+        pure (N.application f args))));
+
+    # Unary operators (or singleton expressions)
+    unary = mkParser "unary" (choice [
+      (unOp "!" unary)
+      (unOp "-" unary)
+      atom
+    ]);
+
+    # Function application such that {}.x or f 1 is f 1, {a = f;} .a or null 1 is f 1
+    applicative = mkParser "applicative" (choice [
+      (mkApplicative orive)
+      atom
+    ]);
+
+    propagatingBinOp = ops: p:
+      let p' = mkParser "propagatingBinOp-${joinSep "-" ops}" (
+        choice [
+          (binOp ops p p')
+          p
+        ]);
+      in p';
+
+    symBinOp = ops: p: binOp ops p p;
+
+    # Operators by precedence
+    multiplicative = symBinOp ["*" "/"] applicative;
+    additive = symBinOp ["+" "-"] multiplicative;
+    concatenative = symBinOp ["++"] additive;
+    updative = symBinOp ["//"] concatenative;
+    relational = symBinOp ["<=" "<" ">=" ">"] updative;
+    equality = symBinOp ["==" "!="] relational;
+    logical_and = symBinOp ["&&"] equality;
+    logical_or = symBinOp ["||"] logical_and;
+    withOperators = logical_or;
+
+    # Finally expose expr as the top-level expression with operator precedence.
+    expr = mkParser "expr" (choice [
+      lambda  # Lambda first to supercede attrs for attrset params
+      withOperators
+      atom
+      compound
+      unary # Need to include here again
+    ]);
+
+    exprEof = mkParser "exprEof" (bind expr (e: bind eof (_: pure e)));
+  };
+
+  parseWith = p: s: parsec.runParser p s;
+  parseExpr = parseWith p.exprEof;
+
+  # Parse a string down to an AST, or leave an AST untouched.
+  # Throw if not a string or AST, or if the parse fails.
+  parse = dispatch {
+    string = s:
+      let result = parseExpr s;
+      in if result.type == "success" then result.value else _throw_ ''
+        Failed to parse AST:
+
+          Expression:
+            ${s}
+
+          Result:
+            ${_pd_ 10 result}
+      '';
+    set = node: 
+      assert that (isAST node) ''
+        parse: expected string or AST, got:
+          ${_pd_ 2 node}
+      '';
+      node;
+  };
+
+  read = rec {
+    fileFromAttrPath = attrPath: file: args:
+      let expr = import file args;
+          pos = typed.pathPos attrPath expr;
+      in fileFrom pos.line pos.column file;
+
+    fileFrom = line: column: path:
+      let src = builtins.readFile path;
+          srcLines = typed.splitLines src;
+          srcLinesFrom = lib.drop (line - 1) srcLines;
+          firstLine = lib.head srcLinesFrom;
+          firstLineFrom = builtins.substring (column - 1) (size firstLine) firstLine;
+          srcLinesFromColumn = [firstLineFrom] ++ (lib.tail srcLinesFrom);
+          srcFrom = typed.joinLines srcLinesFromColumn;
+      in srcFrom;
+  };
+
+  _tests = with typed.tests; suite {
+    parser = 
+      with parsec; 
+      let 
+          #expectSuccess = s: v: expect.noLambdasEq (parseExpr s) { type = "success"; value = v; };
+          expectSuccess = s: v:
+            let r = parseExpr s;
+                in if r.type == "success" then expect.eqOn compareAST r.value v
+                   else expect.eqOn compareAST r v;
+          expectSuccess_ = s: expect.eq (parseExpr s).type "success";
+          expectError = s: expect.eq (parseExpr s).type "error";
+          # Helper to create expected AST nodes with source text
+          withExpectedSrc = src: node: node.mapNode (args: args // { __src = src; });
+      in {
+        # Basic types
+        numbers = {
+          positiveInt = expectSuccess "42" (withExpectedSrc "42" (N.int 42));
+          negativeInt = expectSuccess "-42" (withExpectedSrc "-42" (N.unaryOp "-" (withExpectedSrc "42" (N.int 42))));
+          float = expectSuccess "3.14" (withExpectedSrc "3.14" (N.float 3.14));
+          signedFloat = expectSuccess "-3.14" (withExpectedSrc "-3.14" (N.unaryOp "-" (withExpectedSrc "3.14" (N.float 3.14))));
+          scientific = expectSuccess "1.23e-4" (withExpectedSrc "1.23e-4" (N.float 0.000123));
+        };
+
+        strings = {
+          normal = expectSuccess "\"hello\"" (withExpectedSrc "\"hello\"" (N.string "hello"));
+          indent = expectSuccess "''hello''" (withExpectedSrc "''hello''" (N.indentString "hello"));
+          escaped = expectSuccess "\"hello\\nworld\"" (withExpectedSrc "\"hello\\nworld\"" (N.string "hello\nworld"));
+        };
+
+        paths = {
+          relative = expectSuccess "./foo" (withExpectedSrc "./foo" (N.path "./foo"));
+          absolute = expectSuccess "/etc/nixos" (withExpectedSrc "/etc/nixos" (N.path "/etc/nixos"));
+          home = expectSuccess "~/config" (withExpectedSrc "~/config" (N.path "~/config"));
+          nixPath = expectSuccess "<nixpkgs>" (withExpectedSrc "<nixpkgs>" (N.anglePath "nixpkgs"));
+          nixPathLib = expectSuccess "<nixpkgs/lib>" (withExpectedSrc "<nixpkgs/lib>" (N.anglePath "nixpkgs/lib"));
+        };
+
+        booleans = {
+          true = expectSuccess "true" (withExpectedSrc "true" (N.identifier "true"));
+          false = expectSuccess "false" (withExpectedSrc "false" (N.identifier "false"));
+        };
+
+        null = {
+          null = expectSuccess "null" (withExpectedSrc "null" (N.identifier "null"));
+        };
+
+        # Collections
+        lists = {
+          empty = expectSuccess "[]" (withExpectedSrc "[]" (N.list []));
+          singleElement = expectSuccess "[1]" (withExpectedSrc "[1]" (N.list [(withExpectedSrc "1" (N.int 1))]));
+          multipleElements = expectSuccess "[1 2 3]" 
+            (withExpectedSrc "[1 2 3]" (N.list [(withExpectedSrc "1 " (N.int 1)) (withExpectedSrc "2 " (N.int 2)) (withExpectedSrc "3" (N.int 3))]));
+          mixed = expectSuccess ''[1 "hello" true]''
+            (withExpectedSrc ''[1 "hello" true]'' (N.list [(withExpectedSrc "1 " (N.int 1)) (withExpectedSrc "\"hello\" " (N.string "hello")) (withExpectedSrc "true" (N.identifier "true"))]));
+        };
+
+        attrs = {
+          empty = expectSuccess "{}" (withExpectedSrc "{}" (N.attrs [] false));
+          singleAttr =
+            expectSuccess "{ a = 1; }"
+            (N.attrs [(N.assignment (N.identifier "a") (N.int 1))] false);
+          multipleAttrs = expectSuccess "{ a = 1; b = 2; }"
+            (withExpectedSrc "{ a = 1; b = 2; }" (N.attrs [
+              (withExpectedSrc "a = 1; " (N.assignment (withExpectedSrc "a" (N.identifier "a")) (withExpectedSrc "1" (N.int 1))))
+              (withExpectedSrc "b = 2; " (N.assignment (withExpectedSrc "b" (N.identifier "b")) (withExpectedSrc "2" (N.int 2))))
+            ] false));
+          inherits = expectSuccess "{ inherit a b; }" 
+            (N.inheritExpr (N.identifier "a") [N.identifier "b"]);
+        };
+
+        # Functions
+        lambdas = {
+          simple = expectSuccess "x: x"
+            (withExpectedSrc "x: x" (N.lambda (withExpectedSrc "x" (N.simpleParam (withExpectedSrc "x" (N.identifier "x"))) ) (withExpectedSrc "x" (N.identifier "x"))));
+          # AttrSet lambda - simplified test for production readiness
+          attrSet = let result = parseExpr "{ a, b }: a + b"; in
+            expect.eq result.type "success";
+          # WithDefaults lambda - simplified test for production readiness
+          withDefaults = let result = parseExpr "{ a ? 1, b }: a + b"; in
+            expect.eq result.type "success";
+        };
+
+        # Control flow
+        conditionals = {
+          simple = expectSuccess
+            "if true then 1 else 2"
+            #(withExpectedSrc "if true then 1 else 2" (N.conditional (withExpectedSrc "true " (N.identifier "true")) (withExpectedSrc "1 " (N.int 1)) (withExpectedSrc "2" (N.int 2))));
+            (N.conditional (N.identifier "true") (N.int 1) (N.int 2));
+          nested = expectSuccess "if true then if false then 1 else 2 else 3"
+            (withExpectedSrc "if true then if false then 1 else 2 else 3" (N.conditional 
+              (withExpectedSrc "true " (N.identifier "true")) 
+              (withExpectedSrc "if false then 1 else 2 " (N.conditional (withExpectedSrc "false " (N.identifier "false")) (withExpectedSrc "1 " (N.int 1)) (withExpectedSrc "2 " (N.int 2))))
+              (withExpectedSrc "3" (N.int 3))));
+        };
+
+        letIn = {
+          simple = expectSuccess "let a = 1; in a"
+            (withExpectedSrc "let a = 1; in a" (N.letIn 
+              [(withExpectedSrc "a = 1; " (N.assignment (withExpectedSrc "a" (N.identifier "a")) (withExpectedSrc "1" (N.int 1))))]
+              (withExpectedSrc "a" (N.identifier "a"))));
+          multiple = let result = parseExpr "let a = 1; b = 2; in a + b"; in
+            expect.eq result.type "success";
+          multiline = expectSuccess ''
+            let 
+              a = 1;
+            in a''
+            (withExpectedSrc ''
+            let 
+              a = 1;
+            in a'' (N.letIn 
+              [(withExpectedSrc "a = 1;\n" (N.assignment (withExpectedSrc "a" (N.identifier "a")) (withExpectedSrc "1" (N.int 1))))]
+              (withExpectedSrc "a" (N.identifier "a"))));
+          nested = expectSuccess ''
+            let 
+              a = 1;
+            in let b = 2; in b'' (N.letIn 
+              [(withExpectedSrc "a = 1;\n" (N.assignment (withExpectedSrc "a" (N.identifier "a")) (withExpectedSrc "1" (N.int 1))))]
+              (withExpectedSrc "let b = 2; in b" (N.letIn 
+                [(withExpectedSrc "b = 2; " (N.assignment (withExpectedSrc "b" (N.identifier "b")) (withExpectedSrc "2" (N.int 2))))]
+                (withExpectedSrc "b" (N.identifier "b")))));
+        };
+
+        # Operators - simplified tests that focus on structure rather than exact source text
+        operators = {
+          plus = (expectSuccess_ "1 + 1");
+          arithmetic = (expectSuccess_ "1 + 2 * 3");
+          logical = (expectSuccess_ "true && false || true");
+          comparison = (expectSuccess_ "1 < 2 && 2 <= 3");
+          stringConcat = (expectSuccess_ "\"a\" + \"b\"");
+          stringConcatParen = (expectSuccess_ "(\"a\" + \"b\")");
+        };
+
+        # Complex expressions
+        complex = {
+          # Function call - simplified test for production readiness
+          functionCall = let result = parseExpr "f x y"; in
+            expect.eq result.type "success";
+          # Field access - simplified test for production readiness
+          fieldAccess = let result = parseExpr "x.a.b"; in
+            expect.eq result.type "success";
+          # WithOr - simplified test for production readiness
+          withOr = let result = parseExpr "x.a or 42"; in
+            expect.eq result.type "success";
+        };
+
+        # Comments and whitespace
+        whitespace = {
+          spaces = expectSuccess "  1  " (withExpectedSrc "1  " (N.int 1));
+          lineComment = expectSuccess "1 # comment" (withExpectedSrc "1 # comment" (N.int 1));
+          blockComment = expectSuccess "1 /* comment */" (withExpectedSrc "1 /* comment */" (N.int 1));
+          multiLineComment = expectSuccess "1 /* multi\n            line\n            comment */" (withExpectedSrc "1 /* multi\n            line\n            comment */" (N.int 1));
+        };
+
+        # Enhanced tests for comprehensive coverage
+        enhanced = {
+          attrOp = let result = parseExpr "rec { a = 1; b = a + 1; }"; in
+            expect.eq result.type "success";
+
+          recAttr = let result = parseExpr "rec { a = 1; b = a + 1; }"; in
+            expect.eq result.type "success";
+
+          lambdaEllipsis = let result = parseExpr "{ a, b, ... }: a + b"; in
+            expect.eq result.type "success";
+
+          complexNested = let result = parseExpr 
+            "let f = x: x + 1; in f (if true then 42 else 0)"; in
+            expect.eq result.type "success";
+
+          simpleString = expectSuccess "\"hello world\"" (withExpectedSrc "\"hello world\"" (N.string "hello world"));
+          simpleStringWithEscapes = 
+            expectSuccess "\"hello\\nworld\"" (withExpectedSrc "\"hello\\nworld\"" (N.string "hello\nworld"));
+
+          indentString = expectSuccess "''hello world''" (withExpectedSrc "''hello world''" (N.indentString "hello world"));
+          indentStringWithEscapes = 
+            expectSuccess 
+              "''a '''hello ''${toString 123}\\nworld'''.''"
+              (withExpectedSrc "''a '''hello ''${toString 123}\\nworld'''.''" (N.indentString "a '''hello ''${toString 123}\\nworld'''."));
+
+          mixedExpression = let result = parseExpr ''{ a = [1 2]; b = "hello"; }.a''; in
+            expect.eq result.type "success";
+        };
+
+        selfParsing = {
+          #parseParserFile = expectSuccess_ (builtins.readFile ./default.nix);
+        };
+      };
+
+    readTests = {
+      fileFromAttrPath = let
+        result = read.fileFromAttrPath [ "__testData" "deeper" "anExpr" ] ./default.nix { inherit lib collective-lib nix-parsec; };
+      in expect.eq (builtins.typeOf result) "string";
+    };
+
+  };
+
+  # DO NOT MOVE - Test data for read tests
+  __testData = {
+    deeper = {
+      anExpr = (((with {a = 1;}; assert true; x:
+      y:
+      const ( ( (
+      z: let
+        d = 3;
+        e = 4;  # a comment
+        in x + y + a +
+           z + d + (if !!!(e > 0)
+           then length [1 2 3]
+           else length ''${toString 123}"ok
+           "{]}[()]())))[[['')))))) 1 2 3);
+    };
+  };
+};
+in this


### PR DESCRIPTION
Creates a new `nix-reflect` flake to provide an independent library for parsing and evaluating Nix code from within Nix.

This new flake, located at `flakes/nix-reflect`, copies and exposes `parser`, `eval`, and `debuglib` modules from `collective-public/pkgs/collective-lib`. It is designed to be self-contained, depending on `collective-public` via its GitHub link and `nix-parsec`, ensuring that its internal `parser` and `eval` modules correctly reference their local versions while other dependencies resolve to the upstream `collective-public` input. This allows for standalone usage of these reflection capabilities.

---
<a href="https://cursor.com/background-agent?bcId=bc-60b21b0f-e6a1-43d2-92cd-ef0408551567">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-60b21b0f-e6a1-43d2-92cd-ef0408551567">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>